### PR TITLE
feat(parties): split math, balances, and settle-up (+ tests) — universal debug APK, versioning

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,20 +23,16 @@ jobs:
       - name: Lint & Unit tests
         run: gradle :app:lint :app:testDebugUnitTest --no-daemon --stacktrace
       - name: Build debug APK
-        run: gradle :app:assembleDebug --no-daemon --stacktrace
-      - name: Prepare artifact
-        run: |
-          mkdir -p dist
-          cp app/build/outputs/apk/debug/*.apk dist/
+        run: gradle :app:assembleDebug -PversionCodeOverride=${{ github.run_number }} --no-daemon --stacktrace
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: paisasplit-debug-apk
-          path: dist/*.apk
+          path: app/build/outputs/**/*.apk
       - name: Publish APK to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: debug-${{ github.run_id }}
           name: "SplitPaisa Debug #${{ github.run_number }}"
           prerelease: true
-          files: dist/*.apk
+          files: app/build/outputs/**/*.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
     applicationId = "com.splitpaisa"
     minSdk = 24
     targetSdk = 34
-    versionCode = 1
-    versionName = "0.1"
+    versionCode = project.findProperty("versionCodeOverride")?.toString()?.toInt() ?: 100
+    versionName = "0.3.0"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
@@ -30,6 +30,25 @@ android {
   }
   kotlinOptions {
     jvmTarget = "17"
+  }
+
+  buildTypes {
+    debug {
+      applicationIdSuffix = ".debug"
+      isDebuggable = true
+    }
+  }
+
+  splits {
+    abi {
+      isEnable = false
+    }
+  }
+
+  packaging {
+    resources {
+      excludes += listOf("/META-INF/{AL2.0,LGPL2.1}", "LICENSE*", "LICENSE.txt")
+    }
   }
 }
 
@@ -63,6 +82,7 @@ dependencies {
   testImplementation("androidx.test:core:1.5.0")
   testImplementation("org.robolectric:robolectric:4.11.1")
   testImplementation("androidx.room:room-testing:$roomVersion")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
   androidTestImplementation("androidx.test.ext:junit:1.1.5")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }

--- a/app/src/main/java/com/splitpaisa/core/model/Transaction.kt
+++ b/app/src/main/java/com/splitpaisa/core/model/Transaction.kt
@@ -12,6 +12,7 @@ data class Transaction(
     val categoryId: String? = null,
     val accountId: String? = null,
     val partyId: String? = null,
+    val payerId: String? = null,
     val notes: String? = null,
     val receiptUri: String? = null,
     val recurringMeta: String? = null

--- a/app/src/main/java/com/splitpaisa/core/util/SplitMath.kt
+++ b/app/src/main/java/com/splitpaisa/core/util/SplitMath.kt
@@ -1,0 +1,54 @@
+package com.splitpaisa.core.util
+
+import kotlin.math.roundToLong
+
+object SplitMath {
+    data class Result(val shares: Map<String, Long>, val adjusted: Boolean)
+
+    fun equalSplit(total: Long, memberIds: List<String>): Result {
+        val base = total / memberIds.size
+        val rem = total % memberIds.size
+        val sorted = memberIds.sorted()
+        val map = mutableMapOf<String, Long>()
+        sorted.forEachIndexed { index, id ->
+            map[id] = base + if (index < rem) 1 else 0
+        }
+        return Result(map, rem != 0L)
+    }
+
+    fun unequalSplit(total: Long, shares: Map<String, Long>): Result {
+        val normalized = normalize(shares, total)
+        val adjusted = shares.values.sum() != total
+        return Result(normalized, adjusted)
+    }
+
+    fun percentageSplit(total: Long, percentages: Map<String, Double>): Result {
+        val raw = percentages.mapValues { (_, pct) ->
+            ((total * pct) / 100.0).roundToLong()
+        }
+        val normalized = normalize(raw, total)
+        val adjusted = normalized.values.sum() != raw.values.sum()
+        return Result(normalized, adjusted)
+    }
+
+    fun itemizedSplit(total: Long, items: Map<String, Long>): Result {
+        val normalized = normalize(items, total)
+        val adjusted = items.values.sum() != total
+        return Result(normalized, adjusted)
+    }
+
+    private fun normalize(shares: Map<String, Long>, total: Long): Map<String, Long> {
+        val sum = shares.values.sum()
+        var diff = total - sum
+        if (diff == 0L) return shares
+        val result = shares.toMutableMap()
+        val sorted = shares.keys.sorted()
+        val step = if (diff > 0) 1 else -1
+        for (id in sorted) {
+            if (diff == 0L) break
+            result[id] = result.getValue(id) + step
+            diff -= step
+        }
+        return result
+    }
+}

--- a/app/src/main/java/com/splitpaisa/data/local/dao/SplitDao.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/dao/SplitDao.kt
@@ -14,4 +14,10 @@ interface SplitDao {
 
     @Query("SELECT * FROM splits WHERE transactionId = :transactionId")
     fun byTransaction(transactionId: String): Flow<List<SplitEntity>>
+
+    @Query("SELECT * FROM splits WHERE transactionId IN (SELECT id FROM transactions WHERE partyId = :partyId)")
+    fun byParty(partyId: String): Flow<List<SplitEntity>>
+
+    @Query("DELETE FROM splits WHERE transactionId = :transactionId")
+    suspend fun deleteByTransaction(transactionId: String)
 }

--- a/app/src/main/java/com/splitpaisa/data/local/dao/TransactionDao.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/dao/TransactionDao.kt
@@ -26,4 +26,7 @@ interface TransactionDao {
 
     @Query("SELECT * FROM transactions WHERE atEpochMillis BETWEEN :start AND :end ORDER BY atEpochMillis DESC")
     fun byMonth(start: Long, end: Long): Flow<List<TransactionEntity>>
+
+    @Query("SELECT * FROM transactions WHERE partyId = :partyId")
+    fun byParty(partyId: String): Flow<List<TransactionEntity>>
 }

--- a/app/src/main/java/com/splitpaisa/data/local/entity/SettlementEntity.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/entity/SettlementEntity.kt
@@ -8,10 +8,7 @@ import com.splitpaisa.core.model.Settlement
 @Entity(
     tableName = "settlements",
     indices = [
-        Index(value = ["partyId"]),
-        Index(value = ["payerId"]),
-        Index(value = ["payeeId"]),
-        Index(value = ["atEpochMillis"])
+        Index(value = ["partyId", "payerId", "payeeId", "atEpochMillis"])
     ]
 )
 data class SettlementEntity(

--- a/app/src/main/java/com/splitpaisa/data/local/entity/SplitEntity.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/entity/SplitEntity.kt
@@ -8,8 +8,7 @@ import com.splitpaisa.core.model.Split
 @Entity(
     tableName = "splits",
     indices = [
-        Index(value = ["transactionId"]),
-        Index(value = ["memberId"])
+        Index(value = ["transactionId", "memberId"])
     ]
 )
 data class SplitEntity(

--- a/app/src/main/java/com/splitpaisa/data/local/entity/TransactionEntity.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/entity/TransactionEntity.kt
@@ -24,6 +24,7 @@ data class TransactionEntity(
     val categoryId: String?,
     val accountId: String?,
     val partyId: String?,
+    val payerId: String?,
     val notes: String?,
     val receiptUri: String?,
     val recurringMeta: String?
@@ -37,6 +38,7 @@ data class TransactionEntity(
         categoryId,
         accountId,
         partyId,
+        payerId,
         notes,
         receiptUri,
         recurringMeta
@@ -52,6 +54,7 @@ data class TransactionEntity(
             model.categoryId,
             model.accountId,
             model.partyId,
+            model.payerId,
             model.notes,
             model.receiptUri,
             model.recurringMeta

--- a/app/src/main/java/com/splitpaisa/data/repo/BalanceCalculator.kt
+++ b/app/src/main/java/com/splitpaisa/data/repo/BalanceCalculator.kt
@@ -1,0 +1,34 @@
+package com.splitpaisa.data.repo
+
+import com.splitpaisa.core.model.Settlement
+import com.splitpaisa.core.model.Split
+import com.splitpaisa.core.model.Transaction
+
+/** Utility to compute net balances for party members. */
+object BalanceCalculator {
+    const val YOU_ID = "you"
+
+    fun calculate(
+        transactions: List<Transaction>,
+        splitsByTx: Map<String, List<Split>>,
+        settlements: List<Settlement>,
+        youId: String = YOU_ID
+    ): Balances {
+        val map = mutableMapOf<String, Long>()
+
+        transactions.forEach { t ->
+            val payer = t.payerId ?: youId
+            map[payer] = map.getOrDefault(payer, 0L) + t.amountPaise
+            splitsByTx[t.id].orEmpty().forEach { s ->
+                map[s.memberId] = map.getOrDefault(s.memberId, 0L) - s.sharePaise
+            }
+        }
+
+        settlements.forEach { s ->
+            map[s.payerId] = map.getOrDefault(s.payerId, 0L) + s.amountPaise
+            map[s.payeeId] = map.getOrDefault(s.payeeId, 0L) - s.amountPaise
+        }
+
+        return Balances(map, map[youId] ?: 0L)
+    }
+}

--- a/app/src/main/java/com/splitpaisa/data/repo/Balances.kt
+++ b/app/src/main/java/com/splitpaisa/data/repo/Balances.kt
@@ -1,0 +1,6 @@
+package com.splitpaisa.data.repo
+
+data class Balances(
+    val perMember: Map<String, Long>,
+    val you: Long
+)

--- a/app/src/main/java/com/splitpaisa/data/repo/PartiesRepository.kt
+++ b/app/src/main/java/com/splitpaisa/data/repo/PartiesRepository.kt
@@ -2,12 +2,22 @@ package com.splitpaisa.data.repo
 
 import com.splitpaisa.core.model.Party
 import com.splitpaisa.core.model.PartyMember
+import com.splitpaisa.core.model.Split
+import com.splitpaisa.core.model.Transaction
+import com.splitpaisa.core.model.Settlement
 import com.splitpaisa.data.local.dao.PartyDao
 import com.splitpaisa.data.local.dao.PartyMemberDao
+import com.splitpaisa.data.local.dao.TransactionDao
+import com.splitpaisa.data.local.dao.SplitDao
+import com.splitpaisa.data.local.dao.SettlementDao
 import com.splitpaisa.data.local.entity.PartyEntity
 import com.splitpaisa.data.local.entity.PartyMemberEntity
 import com.splitpaisa.data.local.entity.PartyWithMembers
+import com.splitpaisa.data.local.entity.SettlementEntity
+import com.splitpaisa.data.local.entity.SplitEntity
+import com.splitpaisa.data.local.entity.TransactionEntity
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import java.util.UUID
 
@@ -15,6 +25,16 @@ interface PartiesRepository {
     fun observeParties(): Flow<List<PartyWithMembersBasic>>
     fun getMembers(partyId: String): Flow<List<PartyMember>>
     suspend fun addParty(name: String, members: List<PartyMember>)
+    fun observePartyBalances(partyId: String): Flow<Balances>
+    suspend fun addSettlement(
+        partyId: String,
+        payerId: String,
+        payeeId: String,
+        amountPaise: Long,
+        methodNote: String,
+        atEpochMillis: Long
+    )
+    fun observePartyActivity(partyId: String): Flow<List<PartyActivityItem>>
 }
 
 data class PartyWithMembersBasic(
@@ -22,9 +42,17 @@ data class PartyWithMembersBasic(
     val members: List<PartyMember>
 )
 
+sealed class PartyActivityItem {
+    data class Expense(val transaction: Transaction, val splits: List<Split>) : PartyActivityItem()
+    data class SettlementItem(val settlement: Settlement) : PartyActivityItem()
+}
+
 class PartiesRepositoryImpl(
     private val partyDao: PartyDao,
-    private val memberDao: PartyMemberDao
+    private val memberDao: PartyMemberDao,
+    private val transactionDao: TransactionDao,
+    private val splitDao: SplitDao,
+    private val settlementDao: SettlementDao
 ) : PartiesRepository {
     override fun observeParties(): Flow<List<PartyWithMembersBasic>> =
         partyDao.getPartiesWithMembers().map { list ->
@@ -40,6 +68,60 @@ class PartiesRepositoryImpl(
         partyDao.upsert(party)
         memberDao.upsert(members.map { PartyMemberEntity(it.id, partyId, it.displayName, it.contact) })
     }
+
+    override fun observePartyBalances(partyId: String): Flow<Balances> =
+        combine(
+            transactionDao.byParty(partyId),
+            splitDao.byParty(partyId),
+            settlementDao.byParty(partyId)
+        ) { txs, splits, settlements ->
+            val splitMap = splits.groupBy { it.transactionId }.mapValues { it.value.map(SplitEntity::toModel) }
+            BalanceCalculator.calculate(
+                txs.map(TransactionEntity::toModel),
+                splitMap,
+                settlements.map(SettlementEntity::toModel)
+            )
+        }
+
+    override suspend fun addSettlement(
+        partyId: String,
+        payerId: String,
+        payeeId: String,
+        amountPaise: Long,
+        methodNote: String,
+        atEpochMillis: Long
+    ) {
+        val settlement = Settlement(
+            UUID.randomUUID().toString(),
+            partyId,
+            payerId,
+            payeeId,
+            amountPaise,
+            methodNote,
+            atEpochMillis,
+            null
+        )
+        settlementDao.upsert(SettlementEntity.from(settlement))
+    }
+
+    override fun observePartyActivity(partyId: String): Flow<List<PartyActivityItem>> =
+        combine(
+            transactionDao.byParty(partyId),
+            splitDao.byParty(partyId),
+            settlementDao.byParty(partyId)
+        ) { txs, splits, settlements ->
+            val splitMap = splits.groupBy { it.transactionId }.mapValues { it.value.map(SplitEntity::toModel) }
+            val txItems = txs.map {
+                PartyActivityItem.Expense(it.toModel(), splitMap[it.id] ?: emptyList())
+            }
+            val settleItems = settlements.map { PartyActivityItem.SettlementItem(it.toModel()) }
+            (txItems + settleItems).sortedByDescending {
+                when (it) {
+                    is PartyActivityItem.Expense -> it.transaction.atEpochMillis
+                    is PartyActivityItem.SettlementItem -> it.settlement.atEpochMillis
+                }
+            }
+        }
 
     private fun PartyWithMembers.toBasic() = PartyWithMembersBasic(
         party.toModel(),

--- a/app/src/main/java/com/splitpaisa/di/ServiceLocator.kt
+++ b/app/src/main/java/com/splitpaisa/di/ServiceLocator.kt
@@ -18,8 +18,20 @@ object ServiceLocator {
         CategoriesRepositoryImpl(db(context).categoryDao())
 
     fun transactionsRepository(context: Context): TransactionsRepository =
-        TransactionsRepositoryImpl(db(context).transactionDao(), db(context).categoryDao(), db(context).partyDao())
+        TransactionsRepositoryImpl(
+            db(context),
+            db(context).transactionDao(),
+            db(context).categoryDao(),
+            db(context).partyDao(),
+            db(context).splitDao()
+        )
 
     fun partiesRepository(context: Context): PartiesRepository =
-        PartiesRepositoryImpl(db(context).partyDao(), db(context).partyMemberDao())
+        PartiesRepositoryImpl(
+            db(context).partyDao(),
+            db(context).partyMemberDao(),
+            db(context).transactionDao(),
+            db(context).splitDao(),
+            db(context).settlementDao()
+        )
 }

--- a/app/src/test/java/com/splitpaisa/data/BalancesComputationTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/BalancesComputationTest.kt
@@ -1,0 +1,70 @@
+package com.splitpaisa.data
+
+import androidx.room.Room
+import com.splitpaisa.core.model.PartyMember
+import com.splitpaisa.data.local.db.PaisaSplitDatabase
+import com.splitpaisa.data.repo.PartiesRepository
+import com.splitpaisa.data.repo.PartiesRepositoryImpl
+import com.splitpaisa.data.repo.TransactionsRepository
+import com.splitpaisa.data.repo.TransactionsRepositoryImpl
+import com.splitpaisa.data.repo.PartyExpenseParams
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import androidx.test.core.app.ApplicationProvider
+
+class BalancesComputationTest {
+    private lateinit var db: PaisaSplitDatabase
+    private lateinit var partiesRepo: PartiesRepository
+    private lateinit var transactionsRepo: TransactionsRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        db = Room.inMemoryDatabaseBuilder(context, PaisaSplitDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        partiesRepo = PartiesRepositoryImpl(db.partyDao(), db.partyMemberDao(), db.transactionDao(), db.splitDao(), db.settlementDao())
+        transactionsRepo = TransactionsRepositoryImpl(db, db.transactionDao(), db.categoryDao(), db.partyDao(), db.splitDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun balancesReflectTransactionsAndSettlements() = runBlocking {
+        val partyId = "p1"
+        val members = listOf(
+            PartyMember("you", partyId, "You"),
+            PartyMember("a", partyId, "A"),
+            PartyMember("b", partyId, "B")
+        )
+        partiesRepo.addParty("Party", members)
+
+        transactionsRepo.addPartyExpense(
+            PartyExpenseParams(
+                "Dinner", 1200, null, partyId, "you",
+                mapOf("you" to 400L, "a" to 400L, "b" to 400L),
+                atEpochMillis = 0L
+            )
+        )
+        transactionsRepo.addPartyExpense(
+            PartyExpenseParams(
+                "Taxi", 300, null, partyId, "a",
+                mapOf("you" to 100L, "a" to 100L, "b" to 100L),
+                atEpochMillis = 1L
+            )
+        )
+        partiesRepo.addSettlement(partyId, "a", "you", 200, "cash", 2L)
+
+        val balances = partiesRepo.observePartyBalances(partyId).first()
+        assertEquals(0L, balances.perMember.values.sum())
+        assertEquals(500L, balances.perMember["you"])
+        assertEquals(-500L, balances.perMember["b"])
+    }
+}

--- a/app/src/test/java/com/splitpaisa/data/RepositoryRoundTripTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/RepositoryRoundTripTest.kt
@@ -1,0 +1,75 @@
+package com.splitpaisa.data
+
+import androidx.room.Room
+import com.splitpaisa.core.model.PartyMember
+import com.splitpaisa.data.local.db.PaisaSplitDatabase
+import com.splitpaisa.data.repo.PartiesRepository
+import com.splitpaisa.data.repo.PartiesRepositoryImpl
+import com.splitpaisa.data.repo.TransactionsRepository
+import com.splitpaisa.data.repo.TransactionsRepositoryImpl
+import com.splitpaisa.data.repo.PartyExpenseParams
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import androidx.test.core.app.ApplicationProvider
+
+class RepositoryRoundTripTest {
+    private lateinit var db: PaisaSplitDatabase
+    private lateinit var partiesRepo: PartiesRepository
+    private lateinit var transactionsRepo: TransactionsRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        db = Room.inMemoryDatabaseBuilder(context, PaisaSplitDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        partiesRepo = PartiesRepositoryImpl(db.partyDao(), db.partyMemberDao(), db.transactionDao(), db.splitDao(), db.settlementDao())
+        transactionsRepo = TransactionsRepositoryImpl(db, db.transactionDao(), db.categoryDao(), db.partyDao(), db.splitDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun addEditDeleteExpenseUpdatesBalances() = runBlocking {
+        val partyId = "p1"
+        val members = listOf(
+            PartyMember("you", partyId, "You"),
+            PartyMember("a", partyId, "A")
+        )
+        partiesRepo.addParty("Party", members)
+
+        val id = transactionsRepo.addPartyExpense(
+            PartyExpenseParams(
+                "Lunch", 300, null, partyId, "you",
+                mapOf("you" to 150L, "a" to 150L),
+                atEpochMillis = 0L
+            )
+        )
+        var balances = partiesRepo.observePartyBalances(partyId).first()
+        assertEquals(150L, balances.perMember["you"])
+        assertEquals(-150L, balances.perMember["a"])
+
+        transactionsRepo.editPartyExpense(
+            id,
+            PartyExpenseParams(
+                "Lunch", 400, null, partyId, "you",
+                mapOf("you" to 200L, "a" to 200L),
+                atEpochMillis = 1L
+            )
+        )
+        balances = partiesRepo.observePartyBalances(partyId).first()
+        assertEquals(200L, balances.perMember["you"])
+        assertEquals(-200L, balances.perMember["a"])
+
+        transactionsRepo.deletePartyExpense(id)
+        balances = partiesRepo.observePartyBalances(partyId).first()
+        assertEquals(0L, balances.perMember.values.sum())
+    }
+}

--- a/app/src/test/java/com/splitpaisa/data/local/DatabaseTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/local/DatabaseTest.kt
@@ -52,8 +52,8 @@ class DatabaseTest {
 
     @Test
     fun transactionQueries() = runBlocking {
-        val t1 = TransactionEntity("t1", TransactionType.EXPENSE, "Lunch", 5000, 1, "c1", "a1", null, null, null, null)
-        val t2 = TransactionEntity("t2", TransactionType.INCOME, "Salary", 10000, 2, "c2", "a1", null, null, null, null)
+        val t1 = TransactionEntity("t1", TransactionType.EXPENSE, "Lunch", 5000, 1, "c1", "a1", null, null, null, null, null)
+        val t2 = TransactionEntity("t2", TransactionType.INCOME, "Salary", 10000, 2, "c2", "a1", null, null, null, null, null)
         db.transactionDao().upsert(listOf(t1, t2))
 
         val sumExpense = db.transactionDao().sumByTypeInRange("EXPENSE", 0, 5)
@@ -74,7 +74,7 @@ class DatabaseTest {
             PartyMemberEntity("m2", "p1", "B", null)
         )
         db.partyMemberDao().upsert(members)
-        val tx = TransactionEntity("t1", TransactionType.EXPENSE, "Taxi", 1000, 1, null, null, "p1", null, null, null)
+        val tx = TransactionEntity("t1", TransactionType.EXPENSE, "Taxi", 1000, 1, null, null, "p1", null, null, null, null)
         db.transactionDao().upsert(tx)
         db.splitDao().upsert(listOf(
             SplitEntity("s1", "t1", "m1", 500),

--- a/app/src/test/java/com/splitpaisa/util/SplitRoundingTest.kt
+++ b/app/src/test/java/com/splitpaisa/util/SplitRoundingTest.kt
@@ -1,0 +1,40 @@
+package com.splitpaisa.util
+
+import com.splitpaisa.core.util.SplitMath
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SplitRoundingTest {
+    @Test
+    fun equalSplitRounding() {
+        for (n in 3..7) {
+            val total = 1001L
+            val members = (1..n).map { "m$it" }
+            val result = SplitMath.equalSplit(total, members)
+            assertEquals(total, result.shares.values.sum())
+            val values = result.shares.values
+            assertTrue(values.maxOrNull()!! - values.minOrNull()!! <= 1)
+        }
+    }
+
+    @Test
+    fun percentTrickyTotals() {
+        val total = 1001L
+        val percents = mapOf("a" to 30.0, "b" to 30.0, "c" to 40.0)
+        val result = SplitMath.percentageSplit(total, percents)
+        assertEquals(total, result.shares.values.sum())
+        assertTrue(result.adjusted)
+        assertEquals(301L, result.shares["a"])
+    }
+
+    @Test
+    fun itemizedDrift() {
+        val total = 1001L
+        val items = mapOf("a" to 500L, "b" to 500L)
+        val result = SplitMath.itemizedSplit(total, items)
+        assertEquals(total, result.shares.values.sum())
+        assertTrue(result.adjusted)
+        assertEquals(501L, result.shares["a"])
+    }
+}


### PR DESCRIPTION
## Summary
- implement party split math with paise normalization and a tiny “adjusted by ₹0.01” hint
- compute live party balances and add a settle‑up flow
- add unit tests for split rounding, balance computation, and repository round‑trips
- configure debug APK as universal with applicationIdSuffix `.debug` and CI‑driven versionCode

## Testing
- `gradle :app:lint :app:testDebugUnitTest` *(fails: SDK location not found)*

## Screenshots
![Add expense](https://via.placeholder.com/600x300.png?text=Add+expense+Equal+tab)
![Settle up confirmation](https://via.placeholder.com/600x300.png?text=Settle+up+confirmation)

------
https://chatgpt.com/codex/tasks/task_e_689acc216b588333b36d678064dc4592