### PR TITLE
feat(stats): charts, ranges, and drill-down with Room aggregations (+ tests)

### DIFF
--- a/app/src/main/java/com/splitpaisa/data/local/dao/TransactionDao.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/dao/TransactionDao.kt
@@ -29,4 +29,100 @@ interface TransactionDao {
 
     @Query("SELECT * FROM transactions WHERE partyId = :partyId")
     fun byParty(partyId: String): Flow<List<TransactionEntity>>
+
+    @Query(
+        """
+        SELECT t.categoryId AS categoryId, c.name AS name, c.color AS color, SUM(t.amountPaise) AS spendPaise
+        FROM transactions t JOIN categories c ON c.id = t.categoryId
+        WHERE t.type = 'EXPENSE' AND t.atEpochMillis BETWEEN :start AND :end
+        GROUP BY t.categoryId
+        ORDER BY spendPaise DESC
+        """
+    )
+    fun spendByCategory(start: Long, end: Long): Flow<List<CategorySliceEntity>>
+
+    @Query(
+        """
+        SELECT year, month,
+               SUM(CASE WHEN type='EXPENSE' THEN amountPaise ELSE 0 END) AS spendPaise,
+               SUM(CASE WHEN type='INCOME' THEN amountPaise ELSE 0 END) AS incomePaise
+        FROM (
+            SELECT strftime('%Y', datetime(t.atEpochMillis/1000,'unixepoch')) AS year,
+                   strftime('%m', datetime(t.atEpochMillis/1000,'unixepoch')) AS month,
+                   t.type, t.amountPaise
+            FROM transactions t
+            WHERE t.atEpochMillis BETWEEN :start AND :end
+        )
+        GROUP BY year, month
+        ORDER BY year, month
+        """
+    )
+    fun monthlyTrend(start: Long, end: Long): Flow<List<MonthTrendEntity>>
+
+    @Query(
+        """
+        SELECT c.id AS categoryId, c.name AS name,
+               COALESCE(c.monthlyBudgetPaise,0) AS budgetPaise,
+               COALESCE(SUM(t.amountPaise),0) AS actualPaise
+        FROM categories c
+        LEFT JOIN transactions t ON t.categoryId = c.id
+             AND t.type='EXPENSE'
+             AND t.atEpochMillis BETWEEN :start AND :end
+        WHERE c.monthlyBudgetPaise IS NOT NULL
+        GROUP BY c.id
+        ORDER BY actualPaise DESC
+        """
+    )
+    fun budgetVsActual(start: Long, end: Long): Flow<List<BudgetBarEntity>>
+
+    @Query(
+        """
+        SELECT t.categoryId AS categoryId, c.name AS name, c.color AS color, SUM(t.amountPaise) AS spendPaise
+        FROM transactions t JOIN categories c ON c.id = t.categoryId
+        WHERE t.type = 'EXPENSE' AND t.atEpochMillis BETWEEN :start AND :end
+        GROUP BY t.categoryId
+        ORDER BY spendPaise DESC
+        LIMIT :limit
+        """
+    )
+    fun topCategories(start: Long, end: Long, limit: Int): Flow<List<TopCatEntity>>
+
+    @Query(
+        """
+        SELECT * FROM transactions
+        WHERE atEpochMillis BETWEEN :start AND :end
+          AND (:categoryId IS NULL OR categoryId = :categoryId)
+        ORDER BY atEpochMillis DESC
+        """
+    )
+    fun listTransactions(start: Long, end: Long, categoryId: String?): Flow<List<TransactionEntity>>
 }
+
+data class CategorySliceEntity(
+    val categoryId: String,
+    val name: String,
+    val color: String,
+    val spendPaise: Long,
+)
+
+data class MonthTrendEntity(
+    val year: Int,
+    val month: Int,
+    val spendPaise: Long,
+    val incomePaise: Long,
+)
+
+data class BudgetBarEntity(
+    val categoryId: String,
+    val name: String,
+    val budgetPaise: Long,
+    val actualPaise: Long,
+)
+
+data class TopCatEntity(
+    val categoryId: String,
+    val name: String,
+    val color: String,
+    val spendPaise: Long,
+)
+

--- a/app/src/main/java/com/splitpaisa/data/repo/DateRanges.kt
+++ b/app/src/main/java/com/splitpaisa/data/repo/DateRanges.kt
@@ -1,0 +1,46 @@
+package com.splitpaisa.data.repo
+
+import java.util.Calendar
+
+data class MonthBound(
+    val year: Int,
+    val month: Int,
+    val start: Long,
+    val end: Long,
+)
+
+fun thisMonth(): Pair<Long, Long> {
+    val cal = Calendar.getInstance().apply {
+        set(Calendar.DAY_OF_MONTH, 1)
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }
+    val start = cal.timeInMillis
+    cal.add(Calendar.MONTH, 1)
+    val end = cal.timeInMillis
+    return start to end
+}
+
+fun lastNMonthsBounds(n: Int): List<MonthBound> {
+    val cal = Calendar.getInstance().apply {
+        set(Calendar.DAY_OF_MONTH, 1)
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+        add(Calendar.MONTH, -(n - 1))
+    }
+    val list = mutableListOf<MonthBound>()
+    repeat(n) {
+        val year = cal.get(Calendar.YEAR)
+        val month = cal.get(Calendar.MONTH) + 1
+        val start = cal.timeInMillis
+        cal.add(Calendar.MONTH, 1)
+        val end = cal.timeInMillis
+        list += MonthBound(year, month, start, end)
+    }
+    return list
+}
+

--- a/app/src/main/java/com/splitpaisa/data/repo/TransactionsRepository.kt
+++ b/app/src/main/java/com/splitpaisa/data/repo/TransactionsRepository.kt
@@ -17,8 +17,15 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 
 interface TransactionsRepository {
-    fun observeRecent(limit: Int = 20): Flow<List<TransactionWithCategoryAndPartyBasic>>
+    fun observeRecent(limit: Int = 20): Flow<List<TransactionWithJoins>>
     fun observeMonthSummary(monthStartEpoch: Long, monthEndEpoch: Long): Flow<Summary>
+
+    fun observeSpendByCategory(start: Long, end: Long): Flow<List<CategorySlice>>
+    fun observeMonthlySpendIncome(lastNMonths: Int): Flow<List<MonthPoint>>
+    fun observeBudgetVsActual(start: Long, end: Long): Flow<List<BudgetBar>>
+    fun observeTopCategories(start: Long, end: Long, limit: Int = 5): Flow<List<TopCat>>
+    fun listTransactions(filter: TxFilter): Flow<List<TransactionWithJoins>>
+
     suspend fun addTransaction(t: Transaction)
     suspend fun deleteTransaction(id: String)
 
@@ -27,16 +34,49 @@ interface TransactionsRepository {
     suspend fun deletePartyExpense(id: String)
 }
 
-data class TransactionWithCategoryAndPartyBasic(
+data class TransactionWithJoins(
     val transaction: Transaction,
     val category: Category?,
-    val party: Party?
+    val party: Party?,
 )
 
 data class Summary(
     val spentPaise: Long,
     val incomePaise: Long,
-    val netPaise: Long
+    val netPaise: Long,
+)
+
+data class CategorySlice(
+    val categoryId: String,
+    val name: String,
+    val color: String,
+    val spendPaise: Long,
+)
+
+data class MonthPoint(
+    val year: Int,
+    val month: Int,
+    val spendPaise: Long,
+    val incomePaise: Long,
+)
+
+data class BudgetBar(
+    val categoryId: String,
+    val name: String,
+    val budgetPaise: Long,
+    val actualPaise: Long,
+)
+
+data class TopCat(
+    val categoryId: String,
+    val name: String,
+    val spendPaise: Long,
+)
+
+data class TxFilter(
+    val start: Long,
+    val end: Long,
+    val categoryId: String? = null,
 )
 
 class TransactionsRepositoryImpl(
@@ -44,21 +84,21 @@ class TransactionsRepositoryImpl(
     private val transactionDao: TransactionDao,
     private val categoryDao: CategoryDao,
     private val partyDao: PartyDao,
-    private val splitDao: SplitDao
+    private val splitDao: SplitDao,
 ) : TransactionsRepository {
-    override fun observeRecent(limit: Int): Flow<List<TransactionWithCategoryAndPartyBasic>> =
+    override fun observeRecent(limit: Int): Flow<List<TransactionWithJoins>> =
         combine(
             transactionDao.getRecent(limit),
             categoryDao.getAll(),
-            partyDao.getAll()
+            partyDao.getAll(),
         ) { txs, cats, parties ->
             val catMap = cats.associateBy { it.id }
             val partyMap = parties.associateBy { it.id }
             txs.map { tx ->
-                TransactionWithCategoryAndPartyBasic(
+                TransactionWithJoins(
                     tx.toModel(),
                     catMap[tx.categoryId]?.toModel(),
-                    partyMap[tx.partyId]?.toModel()
+                    partyMap[tx.partyId]?.toModel(),
                 )
             }
         }
@@ -68,6 +108,51 @@ class TransactionsRepositoryImpl(
             val spent = list.filter { it.type == TransactionType.EXPENSE }.sumOf { it.amountPaise }
             val income = list.filter { it.type == TransactionType.INCOME }.sumOf { it.amountPaise }
             Summary(spent, income, income - spent)
+        }
+
+    override fun observeSpendByCategory(start: Long, end: Long): Flow<List<CategorySlice>> =
+        transactionDao.spendByCategory(start, end).map { list ->
+            list.map { CategorySlice(it.categoryId, it.name, it.color, it.spendPaise) }
+        }
+
+    override fun observeMonthlySpendIncome(lastNMonths: Int): Flow<List<MonthPoint>> {
+        val bounds = lastNMonthsBounds(lastNMonths)
+        val start = bounds.first().start
+        val end = bounds.last().end
+        return transactionDao.monthlyTrend(start, end).map { list ->
+            val map = list.associateBy { it.year to it.month }
+            bounds.map { mb ->
+                val point = map[mb.year to mb.month]
+                MonthPoint(mb.year, mb.month, point?.spendPaise ?: 0, point?.incomePaise ?: 0)
+            }
+        }
+    }
+
+    override fun observeBudgetVsActual(start: Long, end: Long): Flow<List<BudgetBar>> =
+        transactionDao.budgetVsActual(start, end).map { list ->
+            list.map { BudgetBar(it.categoryId, it.name, it.budgetPaise, it.actualPaise) }
+        }
+
+    override fun observeTopCategories(start: Long, end: Long, limit: Int): Flow<List<TopCat>> =
+        transactionDao.topCategories(start, end, limit).map { list ->
+            list.map { TopCat(it.categoryId, it.name, it.spendPaise) }
+        }
+
+    override fun listTransactions(filter: TxFilter): Flow<List<TransactionWithJoins>> =
+        combine(
+            transactionDao.listTransactions(filter.start, filter.end, filter.categoryId),
+            categoryDao.getAll(),
+            partyDao.getAll(),
+        ) { txs, cats, parties ->
+            val catMap = cats.associateBy { it.id }
+            val partyMap = parties.associateBy { it.id }
+            txs.map { tx ->
+                TransactionWithJoins(
+                    tx.toModel(),
+                    catMap[tx.categoryId]?.toModel(),
+                    partyMap[tx.partyId]?.toModel(),
+                )
+            }
         }
 
     override suspend fun addTransaction(t: Transaction) {
@@ -93,7 +178,7 @@ class TransactionsRepositoryImpl(
                 params.payerId,
                 params.notes,
                 null,
-                null
+                null,
             )
             transactionDao.upsert(TransactionEntity.from(t))
             val splits = params.shares.map { (memberId, share) ->
@@ -118,7 +203,7 @@ class TransactionsRepositoryImpl(
                 params.payerId,
                 params.notes,
                 null,
-                null
+                null,
             )
             transactionDao.upsert(TransactionEntity.from(t))
             splitDao.deleteByTransaction(id)
@@ -145,5 +230,6 @@ data class PartyExpenseParams(
     val payerId: String,
     val shares: Map<String, Long>,
     val atEpochMillis: Long = System.currentTimeMillis(),
-    val notes: String? = null
+    val notes: String? = null,
 )
+

--- a/app/src/main/java/com/splitpaisa/feature/stats/StatsScreen.kt
+++ b/app/src/main/java/com/splitpaisa/feature/stats/StatsScreen.kt
@@ -1,29 +1,187 @@
 package com.splitpaisa.feature.stats
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.splitpaisa.data.repo.CategorySlice
+import com.splitpaisa.data.repo.TxFilter
+import com.splitpaisa.data.repo.lastNMonthsBounds
 import java.text.NumberFormat
 import java.util.Currency
 import java.util.Locale
 
 @Composable
-fun StatsScreen(viewModel: StatsViewModel) {
+fun StatsScreen(viewModel: StatsViewModel, onNavigate: (TxFilter) -> Unit = {}) {
     val state by viewModel.uiState.collectAsState()
-    val formatter = NumberFormat.getCurrencyInstance(Locale("en", "IN")).apply {
-        currency = Currency.getInstance("INR")
+    val formatter = remember {
+        NumberFormat.getCurrencyInstance(Locale("en", "IN")).apply {
+            currency = Currency.getInstance("INR")
+        }
     }
-    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text("Stats", style = MaterialTheme.typography.titleLarge)
-        Text("Total expense: ${formatter.format(state.totalExpense / 100.0)}", color = Color.Red)
-        Text("Total income: ${formatter.format(state.totalIncome / 100.0)}", color = Color.Green)
+
+    LazyColumn(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = viewModel::setThisMonth, enabled = state.selection != RangeSelection.THIS_MONTH) { Text("This Month") }
+                Button(onClick = viewModel::setLastSixMonths, enabled = state.selection != RangeSelection.LAST_SIX_MONTHS) { Text("Last 6") }
+            }
+        }
+        item {
+            Text("Spend by Category", style = MaterialTheme.typography.titleMedium)
+            if (state.spendByCategory.isEmpty()) {
+                Text("No expenses in this range.")
+            } else {
+                SpendByCategoryChart(state.spendByCategory) { cat ->
+                    onNavigate(viewModel.filterForCategory(cat))
+                }
+            }
+        }
+        item {
+            Text("Monthly Trend", style = MaterialTheme.typography.titleMedium)
+            MonthlyTrendChart(state.monthlyTrend) { index ->
+                val bounds = lastNMonthsBounds(state.monthlyTrend.size)
+                val b = bounds[index]
+                onNavigate(TxFilter(b.start, b.end))
+            }
+        }
+        item {
+            Text("Budget vs Actual", style = MaterialTheme.typography.titleMedium)
+            if (state.budgetBars.isEmpty()) {
+                Text("No budgets.")
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    state.budgetBars.forEach { bar ->
+                        Column(modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onNavigate(viewModel.filterForCategory(bar.categoryId)) }) {
+                            Text(bar.name)
+                            val progress = if (bar.budgetPaise == 0L) 0f else bar.actualPaise.toFloat() / bar.budgetPaise
+                            Box(Modifier.fillMaxWidth().height(8.dp).background(Color.LightGray)) {
+                                Box(
+                                    Modifier
+                                        .fillMaxWidth(progress.coerceAtMost(1f))
+                                        .height(8.dp)
+                                        .background(if (progress > 1f) Color.Red else Color.Green)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        item {
+            Text("Top Categories", style = MaterialTheme.typography.titleMedium)
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                state.topCategories.forEach { cat ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onNavigate(viewModel.filterForCategory(cat.categoryId)) },
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(cat.name)
+                        Text(formatter.format(cat.spendPaise / 100.0))
+                    }
+                }
+            }
+        }
     }
 }
+
+@Composable
+private fun SpendByCategoryChart(data: List<CategorySlice>, onSlice: (String?) -> Unit) {
+    val total = data.sumOf { it.spendPaise }
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Canvas(modifier = Modifier.size(160.dp)) {
+            var startAngle = -90f
+            data.forEach { slice ->
+                val sweep = if (total == 0L) 0f else (slice.spendPaise.toFloat() / total) * 360f
+                drawArc(
+                    color = Color(android.graphics.Color.parseColor(slice.color)),
+                    startAngle = startAngle,
+                    sweepAngle = sweep,
+                    useCenter = true,
+                )
+                startAngle += sweep
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        data.forEach { slice ->
+            Row(
+                modifier = Modifier
+                    .clickable { onSlice(slice.categoryId) }
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    Modifier
+                        .size(12.dp)
+                        .background(Color(android.graphics.Color.parseColor(slice.color)))
+                )
+                Text(slice.name, modifier = Modifier.padding(start = 8.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun MonthlyTrendChart(points: List<com.splitpaisa.data.repo.MonthPoint>, onClick: (Int) -> Unit) {
+    val maxVal = (points.maxOfOrNull { maxOf(it.spendPaise, it.incomePaise) } ?: 0).toFloat()
+    Column {
+        Canvas(modifier = Modifier.fillMaxWidth().height(120.dp)) {
+            if (points.isEmpty() || maxVal == 0f) return@Canvas
+            val width = size.width
+            val height = size.height
+            val stepX = width / (points.size - 1)
+            var prevExpense: Offset? = null
+            var prevIncome: Offset? = null
+            points.forEachIndexed { index, p ->
+                val x = stepX * index
+                val spendY = height - (p.spendPaise / maxVal) * height
+                val incomeY = height - (p.incomePaise / maxVal) * height
+                val spendPt = Offset(x, spendY)
+                val incomePt = Offset(x, incomeY)
+                if (prevExpense != null) drawLine(Color.Red, prevExpense!!, spendPt)
+                if (prevIncome != null) drawLine(Color.Green, prevIncome!!, incomePt)
+                prevExpense = spendPt
+                prevIncome = incomePt
+            }
+        }
+        Row(horizontalArrangement = Arrangement.SpaceEvenly, modifier = Modifier.fillMaxWidth()) {
+            points.forEachIndexed { index, p ->
+                Text(
+                    "${p.month}/${p.year % 100}",
+                    modifier = Modifier.clickable { onClick(index) },
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/splitpaisa/feature/transactions/FilteredTransactionsScreen.kt
+++ b/app/src/main/java/com/splitpaisa/feature/transactions/FilteredTransactionsScreen.kt
@@ -1,0 +1,50 @@
+package com.splitpaisa.feature.transactions
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import java.text.NumberFormat
+import java.util.Currency
+import java.util.Locale
+
+@Composable
+fun FilteredTransactionsScreen(viewModel: FilteredTransactionsViewModel) {
+    val state by viewModel.uiState.collectAsState()
+    val formatter = NumberFormat.getCurrencyInstance(Locale("en", "IN")).apply {
+        currency = Currency.getInstance("INR")
+    }
+
+    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("Transactions", style = MaterialTheme.typography.titleLarge)
+        LazyColumn {
+            items(state.transactions) { wrapper ->
+                val t = wrapper.transaction
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column { Text(t.title); Text(t.type.name) }
+                    val color = if (t.type.name == "EXPENSE") Color.Red else Color.Green
+                    Text(formatter.format(t.amountPaise / 100.0), color = color)
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/splitpaisa/feature/transactions/FilteredTransactionsViewModel.kt
+++ b/app/src/main/java/com/splitpaisa/feature/transactions/FilteredTransactionsViewModel.kt
@@ -1,0 +1,36 @@
+package com.splitpaisa.feature.transactions
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.splitpaisa.data.repo.TxFilter
+import com.splitpaisa.data.repo.TransactionWithJoins
+import com.splitpaisa.data.repo.TransactionsRepository
+import com.splitpaisa.di.ServiceLocator
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+data class FilteredTxUiState(val transactions: List<TransactionWithJoins> = emptyList())
+
+class FilteredTransactionsViewModel(
+    private val repo: TransactionsRepository,
+    private val filter: TxFilter,
+) : ViewModel() {
+    val uiState: StateFlow<FilteredTxUiState> = repo.listTransactions(filter)
+        .map { FilteredTxUiState(it) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), FilteredTxUiState())
+
+    companion object {
+        fun factory(context: android.content.Context, filter: TxFilter): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val repo = ServiceLocator.transactionsRepository(context)
+                    @Suppress("UNCHECKED_CAST")
+                    return FilteredTransactionsViewModel(repo, filter) as T
+                }
+            }
+    }
+}
+

--- a/app/src/main/java/com/splitpaisa/navigation/NavGraph.kt
+++ b/app/src/main/java/com/splitpaisa/navigation/NavGraph.kt
@@ -2,11 +2,13 @@ package com.splitpaisa.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.navArgument
 import com.splitpaisa.feature.add.AddScreen
 import com.splitpaisa.feature.add.AddViewModel
 import com.splitpaisa.feature.home.HomeScreen
@@ -17,6 +19,9 @@ import com.splitpaisa.feature.settings.SettingsScreen
 import com.splitpaisa.feature.settings.SettingsViewModel
 import com.splitpaisa.feature.stats.StatsScreen
 import com.splitpaisa.feature.stats.StatsViewModel
+import com.splitpaisa.feature.transactions.FilteredTransactionsScreen
+import com.splitpaisa.feature.transactions.FilteredTransactionsViewModel
+import com.splitpaisa.data.repo.TxFilter
 
 @Composable
 fun PaisaNavGraph(
@@ -38,7 +43,26 @@ fun PaisaNavGraph(
         composable(Destinations.Stats.route) {
             val context = LocalContext.current
             val vm: StatsViewModel = viewModel(factory = StatsViewModel.factory(context))
-            StatsScreen(vm)
+            StatsScreen(vm) { filter ->
+                val category = filter.categoryId ?: ""
+                navController.navigate("${Destinations.Filtered.route}?start=${filter.start}&end=${filter.end}&categoryId=${category}")
+            }
+        }
+        composable(
+            route = Destinations.Filtered.route + "?start={start}&end={end}&categoryId={categoryId}",
+            arguments = listOf(
+                navArgument("start") { type = NavType.LongType },
+                navArgument("end") { type = NavType.LongType },
+                navArgument("categoryId") { type = NavType.StringType; defaultValue = "" }
+            )
+        ) { backStackEntry ->
+            val start = backStackEntry.arguments?.getLong("start") ?: 0L
+            val end = backStackEntry.arguments?.getLong("end") ?: 0L
+            val cat = backStackEntry.arguments?.getString("categoryId").takeIf { !it.isNullOrEmpty() }
+            val context = LocalContext.current
+            val filter = TxFilter(start, end, cat)
+            val vm: FilteredTransactionsViewModel = viewModel(factory = FilteredTransactionsViewModel.factory(context, filter))
+            FilteredTransactionsScreen(vm)
         }
         composable(Destinations.Settings.route) {
             SettingsScreen(settingsViewModel)
@@ -56,4 +80,5 @@ sealed class Destinations(val route: String) {
     object Stats : Destinations("stats")
     object Settings : Destinations("settings")
     object Add : Destinations("add")
+    object Filtered : Destinations("transactions")
 }

--- a/app/src/test/java/com/splitpaisa/data/FilteringTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/FilteringTest.kt
@@ -1,0 +1,61 @@
+package com.splitpaisa.data
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.splitpaisa.core.model.TransactionType
+import com.splitpaisa.data.local.db.PaisaSplitDatabase
+import com.splitpaisa.data.local.entity.CategoryEntity
+import com.splitpaisa.data.local.entity.TransactionEntity
+import com.splitpaisa.data.repo.TxFilter
+import com.splitpaisa.data.repo.TransactionsRepository
+import com.splitpaisa.data.repo.TransactionsRepositoryImpl
+import com.splitpaisa.data.repo.lastNMonthsBounds
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FilteringTest {
+    private lateinit var db: PaisaSplitDatabase
+    private lateinit var repo: TransactionsRepository
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        db = Room.inMemoryDatabaseBuilder(context, PaisaSplitDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repo = TransactionsRepositoryImpl(
+            db,
+            db.transactionDao(),
+            db.categoryDao(),
+            db.partyDao(),
+            db.splitDao()
+        )
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    @Test
+    fun listTransactions_filtersByCategoryAndDate() = runBlocking {
+        val cat1 = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null)
+        val cat2 = CategoryEntity("c2", "Travel", TransactionType.EXPENSE, "ic", "#00ff00", null)
+        db.categoryDao().upsert(listOf(cat1, cat2))
+        val bounds = lastNMonthsBounds(1).first()
+        db.transactionDao().upsert(listOf(
+            TransactionEntity("t1", TransactionType.EXPENSE, "A", 1000, bounds.start + 1, "c1", null, null, null, null, null, null),
+            TransactionEntity("t2", TransactionType.EXPENSE, "B", 2000, bounds.start - 1000, "c1", null, null, null, null, null, null),
+            TransactionEntity("t3", TransactionType.EXPENSE, "C", 3000, bounds.start + 2, "c2", null, null, null, null, null, null)
+        ))
+        val list = repo.listTransactions(TxFilter(bounds.start, bounds.end, "c1")).first()
+        assertEquals(1, list.size)
+        assertEquals("t1", list.first().transaction.id)
+    }
+}
+

--- a/app/src/test/java/com/splitpaisa/data/StatsAggregationTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/StatsAggregationTest.kt
@@ -1,0 +1,105 @@
+package com.splitpaisa.data
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.splitpaisa.core.model.TransactionType
+import com.splitpaisa.data.local.db.PaisaSplitDatabase
+import com.splitpaisa.data.local.entity.CategoryEntity
+import com.splitpaisa.data.local.entity.TransactionEntity
+import com.splitpaisa.data.repo.TransactionsRepository
+import com.splitpaisa.data.repo.TransactionsRepositoryImpl
+import com.splitpaisa.data.repo.lastNMonthsBounds
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StatsAggregationTest {
+    private lateinit var db: PaisaSplitDatabase
+    private lateinit var repo: TransactionsRepository
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        db = Room.inMemoryDatabaseBuilder(context, PaisaSplitDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repo = TransactionsRepositoryImpl(
+            db,
+            db.transactionDao(),
+            db.categoryDao(),
+            db.partyDao(),
+            db.splitDao()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun spendByCategory_sumsAndSorts() = runBlocking {
+        val food = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null)
+        val travel = CategoryEntity("c2", "Travel", TransactionType.EXPENSE, "ic", "#00ff00", null)
+        db.categoryDao().upsert(listOf(food, travel))
+        val (start, end) = lastNMonthsBounds(1).first().run { start to end }
+        db.transactionDao().upsert(listOf(
+            TransactionEntity("t1", TransactionType.EXPENSE, "A", 1000, start + 1, "c1", null, null, null, null, null, null),
+            TransactionEntity("t2", TransactionType.EXPENSE, "B", 2000, start + 2, "c2", null, null, null, null, null, null)
+        ))
+        val slices = repo.observeSpendByCategory(start, end).first()
+        assertEquals(2, slices.size)
+        assertEquals("c2", slices.first().categoryId)
+    }
+
+    @Test
+    fun monthlyTrend_gapFilled() = runBlocking {
+        val bounds = lastNMonthsBounds(3)
+        val food = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null)
+        db.categoryDao().upsert(listOf(food))
+        db.transactionDao().upsert(
+            TransactionEntity("t1", TransactionType.EXPENSE, "A", 1000, bounds[0].start + 1, "c1", null, null, null, null, null, null)
+        )
+        val trend = repo.observeMonthlySpendIncome(3).first()
+        assertEquals(3, trend.size)
+        assertEquals(1000, trend[0].spendPaise)
+        assertEquals(0, trend[1].spendPaise)
+    }
+
+    @Test
+    fun budgetVsActual_basic() = runBlocking {
+        val cat = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", 2000)
+        db.categoryDao().upsert(listOf(cat))
+        val (start, end) = lastNMonthsBounds(1).first().run { start to end }
+        db.transactionDao().upsert(
+            TransactionEntity("t1", TransactionType.EXPENSE, "A", 2500, start + 1, "c1", null, null, null, null, null, null)
+        )
+        val bars = repo.observeBudgetVsActual(start, end).first()
+        assertEquals(1, bars.size)
+        assertEquals(2500, bars.first().actualPaise)
+    }
+
+    @Test
+    fun topCategories_limit() = runBlocking {
+        val food = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null)
+        val travel = CategoryEntity("c2", "Travel", TransactionType.EXPENSE, "ic", "#00ff00", null)
+        val rent = CategoryEntity("c3", "Rent", TransactionType.EXPENSE, "ic", "#0000ff", null)
+        db.categoryDao().upsert(listOf(food, travel, rent))
+        val (start, end) = lastNMonthsBounds(1).first().run { start to end }
+        db.transactionDao().upsert(listOf(
+            TransactionEntity("t1", TransactionType.EXPENSE, "A", 1000, start + 1, "c1", null, null, null, null, null, null),
+            TransactionEntity("t2", TransactionType.EXPENSE, "B", 2000, start + 2, "c2", null, null, null, null, null, null),
+            TransactionEntity("t3", TransactionType.EXPENSE, "C", 3000, start + 3, "c3", null, null, null, null, null, null)
+        ))
+        val top = repo.observeTopCategories(start, end, limit = 2).first()
+        assertEquals(2, top.size)
+        assertEquals("c3", top[0].categoryId)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Flow-based Room aggregation APIs for category slices, monthly trend, budgets, top categories, and filtered lists
- build Stats UI with range toggles, Canvas charts, and drill-down navigation to a filtered transactions list
- provide date range helpers and unit tests validating aggregations and filtering

![stats light](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAB4CAIAAAA48Cq8AAABcUlEQVR4nO3ZMQ6DMBAAQYz4/5edjhIoskSxZloorlidLXnMOTf4tv3XA7AmYZEQFglhkRAWCWGREBYJYZEQFonj+vMY74zBX7p4tbGxSAiLxM1RePJUzenJBcnGIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSwiIhLBLCIiEsEsIiISwSx8P/xkjHYDU2Fglhkbg5Cud8ZwxWY2OREBYJYZEQFglhkRAWCWGREBaJD/a3CfUt5c5mAAAAAElFTkSuQmCC)
![stats dark](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAB4CAIAAAA48Cq8AAABRElEQVR4nO3WsQ2AMAwAQUDsv3KYAJSCRwLu2rhw8bKyLAAAAAAAwH3W6+cxnlmDV1rP89keXIMfERaJfXLu4ujxNzMfJBeLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEgIi4SwSAiLhLBICIuEsEjsk3NjpGvwNS4WCWEBAAAAAMCdDrf2BswUGM2dAAAAAElFTkSuQmCC)

## Testing
- `gradle :app:lint :app:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b0ab0b4a883339c1a1b26a893d7a0