### PR TITLE
feat(search): fuzzy member & global search with MRU (lightweight, no heavy deps; no Gradle in Codex)

### DIFF
--- a/app/src/main/java/com/splitpaisa/core/search/Fuzzy.kt
+++ b/app/src/main/java/com/splitpaisa/core/search/Fuzzy.kt
@@ -1,0 +1,61 @@
+package com.splitpaisa.core.search
+
+object Fuzzy {
+    fun rank(query: String, candidate: String): Int {
+        val qTokens = TextNormalizer.tokenize(query)
+        val cTokens = TextNormalizer.tokenize(candidate)
+        return rankTokens(qTokens, cTokens)
+    }
+
+    fun rankTokens(qTokens: List<String>, cTokens: List<String>): Int {
+        if (qTokens.isEmpty() || cTokens.isEmpty()) return 0
+        val query = qTokens.joinToString(" ")
+        val candidate = cTokens.joinToString(" ")
+        var score = 0
+        if (candidate == query) score += 1000
+        if (candidate.startsWith(query)) score += 500
+        if (candidate.contains(query)) score += 100
+        // token overlap and order
+        var lastIndex = -1
+        var overlap = 0
+        for (q in qTokens) {
+            val idx = cTokens.indexOfFirst { it.startsWith(q) }
+            if (idx >= 0) {
+                overlap++
+                if (lastIndex >= 0 && idx == lastIndex + 1) score += 20
+                if (idx == overlap - 1) score += 10
+                lastIndex = idx
+            } else {
+                // small edit distance bonus
+                cTokens.forEach { token ->
+                    val dist = editDistance(q, token)
+                    if (dist == 1) score += 5
+                    else if (dist == 2) score += 2
+                }
+            }
+        }
+        score += overlap * 50
+        // starts with bonus
+        if (cTokens.first().startsWith(qTokens.first())) score += 30
+        // shorter candidate preferred
+        score -= candidate.length
+        return score
+    }
+
+    private fun editDistance(a: String, b: String): Int {
+        val dp = Array(a.length + 1) { IntArray(b.length + 1) }
+        for (i in 0..a.length) dp[i][0] = i
+        for (j in 0..b.length) dp[0][j] = j
+        for (i in 1..a.length) {
+            for (j in 1..b.length) {
+                val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+                dp[i][j] = minOf(
+                    dp[i - 1][j] + 1,
+                    dp[i][j - 1] + 1,
+                    dp[i - 1][j - 1] + cost
+                )
+            }
+        }
+        return dp[a.length][b.length]
+    }
+}

--- a/app/src/main/java/com/splitpaisa/core/search/TextNormalizer.kt
+++ b/app/src/main/java/com/splitpaisa/core/search/TextNormalizer.kt
@@ -1,0 +1,16 @@
+package com.splitpaisa.core.search
+
+object TextNormalizer {
+    private val spaceRegex = "\\s+".toRegex()
+    private val diacriticsRegex = "\\p{Mn}+".toRegex()
+
+    fun normalize(input: String): String {
+        val lower = input.lowercase()
+        val normalized = java.text.Normalizer.normalize(lower, java.text.Normalizer.Form.NFD)
+        val noDiacritics = diacriticsRegex.replace(normalized, "")
+        return spaceRegex.replace(noDiacritics, " ").trim()
+    }
+
+    fun tokenize(input: String): List<String> =
+        normalize(input).split(' ').filter { it.isNotEmpty() }
+}

--- a/app/src/main/java/com/splitpaisa/data/local/dao/CategoryDao.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/dao/CategoryDao.kt
@@ -20,4 +20,7 @@ interface CategoryDao {
 
     @Query("SELECT * FROM categories WHERE kind = 'INCOME'")
     fun getIncomeCategories(): Flow<List<CategoryEntity>>
+
+    @Query("SELECT * FROM categories WHERE normalizedName LIKE '%' || :needle || '%' OR LOWER(name) LIKE '%' || :needle || '%' LIMIT :limit")
+    suspend fun search(needle: String, limit: Int): List<CategoryEntity>
 }

--- a/app/src/main/java/com/splitpaisa/data/local/dao/PartyDao.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/dao/PartyDao.kt
@@ -20,4 +20,7 @@ interface PartyDao {
     @Transaction
     @Query("SELECT * FROM parties")
     fun getPartiesWithMembers(): Flow<List<PartyWithMembers>>
+
+    @Query("SELECT * FROM parties WHERE LOWER(name) LIKE '%' || :needle || '%' LIMIT :limit")
+    suspend fun search(needle: String, limit: Int): List<PartyEntity>
 }

--- a/app/src/main/java/com/splitpaisa/data/local/dao/PartyMemberDao.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/dao/PartyMemberDao.kt
@@ -14,4 +14,7 @@ interface PartyMemberDao {
 
     @Query("SELECT * FROM party_members WHERE partyId = :partyId")
     fun byParty(partyId: String): Flow<List<PartyMemberEntity>>
+
+    @Query("SELECT * FROM party_members WHERE normalizedName LIKE '%' || :needle || '%' OR LOWER(displayName) LIKE '%' || :needle || '%' LIMIT :limit")
+    suspend fun search(needle: String, limit: Int): List<PartyMemberEntity>
 }

--- a/app/src/main/java/com/splitpaisa/data/local/dao/RecentSearchDao.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/dao/RecentSearchDao.kt
@@ -1,0 +1,20 @@
+package com.splitpaisa.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.splitpaisa.data.local.entity.RecentSearchEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface RecentSearchDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: RecentSearchEntity)
+
+    @Query("SELECT query FROM recent_searches ORDER BY updatedAt DESC LIMIT :limit")
+    fun recentQueries(limit: Int): Flow<List<String>>
+
+    @Query("DELETE FROM recent_searches")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/splitpaisa/data/local/dao/TransactionDao.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/dao/TransactionDao.kt
@@ -30,6 +30,9 @@ interface TransactionDao {
     @Query("SELECT * FROM transactions WHERE partyId = :partyId")
     fun byParty(partyId: String): Flow<List<TransactionEntity>>
 
+    @Query("SELECT * FROM transactions WHERE LOWER(title) LIKE '%' || :needle || '%' LIMIT :limit")
+    suspend fun search(needle: String, limit: Int): List<TransactionEntity>
+
     @Query(
         """
         SELECT t.categoryId AS categoryId, c.name AS name, c.color AS color, SUM(t.amountPaise) AS spendPaise

--- a/app/src/main/java/com/splitpaisa/data/local/entity/CategoryEntity.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/entity/CategoryEntity.kt
@@ -5,10 +5,11 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.splitpaisa.core.model.Category
 import com.splitpaisa.core.model.TransactionType
+import com.splitpaisa.core.search.TextNormalizer
 
 @Entity(
     tableName = "categories",
-    indices = [Index(value = ["name"])]
+    indices = [Index(value = ["name"]), Index(value = ["normalizedName"])]
 )
 data class CategoryEntity(
     @PrimaryKey val id: String,
@@ -16,11 +17,20 @@ data class CategoryEntity(
     val kind: TransactionType,
     val icon: String,
     val color: String,
-    val monthlyBudgetPaise: Long?
+    val monthlyBudgetPaise: Long?,
+    val normalizedName: String,
 ) {
     fun toModel() = Category(id, name, kind, icon, color, monthlyBudgetPaise)
 
     companion object {
-        fun from(model: Category) = CategoryEntity(model.id, model.name, model.kind, model.icon, model.color, model.monthlyBudgetPaise)
+        fun from(model: Category) = CategoryEntity(
+            model.id,
+            model.name,
+            model.kind,
+            model.icon,
+            model.color,
+            model.monthlyBudgetPaise,
+            TextNormalizer.normalize(model.name)
+        )
     }
 }

--- a/app/src/main/java/com/splitpaisa/data/local/entity/PartyMemberEntity.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/entity/PartyMemberEntity.kt
@@ -4,20 +4,31 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.splitpaisa.core.model.PartyMember
+import com.splitpaisa.core.search.TextNormalizer
 
 @Entity(
     tableName = "party_members",
-    indices = [Index(value = ["partyId", "displayName"], unique = true)]
+    indices = [
+        Index(value = ["partyId", "displayName"], unique = true),
+        Index(value = ["normalizedName"])
+    ]
 )
 data class PartyMemberEntity(
     @PrimaryKey val id: String,
     val partyId: String,
     val displayName: String,
-    val contact: String?
+    val contact: String?,
+    val normalizedName: String,
 ) {
     fun toModel() = PartyMember(id, partyId, displayName, contact)
 
     companion object {
-        fun from(model: PartyMember) = PartyMemberEntity(model.id, model.partyId, model.displayName, model.contact)
+        fun from(model: PartyMember) = PartyMemberEntity(
+            model.id,
+            model.partyId,
+            model.displayName,
+            model.contact,
+            TextNormalizer.normalize(model.displayName)
+        )
     }
 }

--- a/app/src/main/java/com/splitpaisa/data/local/entity/RecentSearchEntity.kt
+++ b/app/src/main/java/com/splitpaisa/data/local/entity/RecentSearchEntity.kt
@@ -1,0 +1,10 @@
+package com.splitpaisa.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "recent_searches")
+data class RecentSearchEntity(
+    @PrimaryKey val query: String,
+    val updatedAt: Long,
+)

--- a/app/src/main/java/com/splitpaisa/data/repo/SearchRepository.kt
+++ b/app/src/main/java/com/splitpaisa/data/repo/SearchRepository.kt
@@ -1,0 +1,64 @@
+package com.splitpaisa.data.repo
+
+import com.splitpaisa.core.model.Category
+import com.splitpaisa.core.model.Party
+import com.splitpaisa.core.model.Transaction
+import com.splitpaisa.core.search.Fuzzy
+import com.splitpaisa.core.search.TextNormalizer
+import com.splitpaisa.data.local.dao.CategoryDao
+import com.splitpaisa.data.local.dao.PartyDao
+import com.splitpaisa.data.local.dao.RecentSearchDao
+import com.splitpaisa.data.local.dao.TransactionDao
+import com.splitpaisa.data.local.entity.RecentSearchEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+data class SearchResults(
+    val transactions: List<Transaction>,
+    val categories: List<Category>,
+    val parties: List<Party>
+)
+
+interface SearchRepository {
+    fun searchAll(query: String, limitPerType: Int = 10): Flow<SearchResults>
+    suspend fun recordRecentQuery(query: String)
+    fun recentQueries(limit: Int = 10): Flow<List<String>>
+}
+
+class SearchRepositoryImpl(
+    private val categoryDao: CategoryDao,
+    private val partyDao: PartyDao,
+    private val transactionDao: TransactionDao,
+    private val recentDao: RecentSearchDao,
+) : SearchRepository {
+    override fun searchAll(query: String, limitPerType: Int): Flow<SearchResults> = flow {
+        if (query.isBlank()) {
+            emit(SearchResults(emptyList(), emptyList(), emptyList()))
+        } else {
+            val needle = TextNormalizer.normalize(query)
+            val catEntities = categoryDao.search(needle, limitPerType * 5)
+            val partyEntities = partyDao.search(needle, limitPerType * 5)
+            val txEntities = transactionDao.search(needle, limitPerType * 5)
+            val categories = rank(query, catEntities) { it.name }.map { it.toModel() }.take(limitPerType)
+            val parties = rank(query, partyEntities) { it.name }.map { it.toModel() }.take(limitPerType)
+            val txs = rank(query, txEntities) { it.title }.map { it.toModel() }.take(limitPerType)
+            emit(SearchResults(txs, categories, parties))
+        }
+    }
+
+    override suspend fun recordRecentQuery(query: String) {
+        val norm = TextNormalizer.normalize(query)
+        recentDao.upsert(RecentSearchEntity(norm, System.currentTimeMillis()))
+    }
+
+    override fun recentQueries(limit: Int): Flow<List<String>> = recentDao.recentQueries(limit)
+
+    private fun <T> rank(query: String, list: List<T>, name: (T) -> String): List<T> {
+        return list.map { it to Fuzzy.rank(query, name(it)) }
+            .sortedWith(
+                compareByDescending<Pair<T, Int>> { it.second }
+                    .thenBy { name(it.first).length }
+                    .thenBy { name(it.first) }
+            ).map { it.first }
+    }
+}

--- a/app/src/main/java/com/splitpaisa/di/ServiceLocator.kt
+++ b/app/src/main/java/com/splitpaisa/di/ServiceLocator.kt
@@ -34,4 +34,12 @@ object ServiceLocator {
             db(context).splitDao(),
             db(context).settlementDao()
         )
+
+    fun searchRepository(context: Context): SearchRepository =
+        SearchRepositoryImpl(
+            db(context).categoryDao(),
+            db(context).partyDao(),
+            db(context).transactionDao(),
+            db(context).recentSearchDao(),
+        )
 }

--- a/app/src/test/java/com/splitpaisa/core/search/FuzzyRankTest.kt
+++ b/app/src/test/java/com/splitpaisa/core/search/FuzzyRankTest.kt
@@ -1,0 +1,35 @@
+package com.splitpaisa.core.search
+
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FuzzyRankTest {
+    @Test
+    fun exact_prefix_substring() {
+        val exact = Fuzzy.rank("meera", "Meera")
+        val prefix = Fuzzy.rank("mee", "Meera")
+        val substr = Fuzzy.rank("eer", "Meera")
+        assertTrue(exact > prefix)
+        assertTrue(prefix > substr)
+    }
+
+    @Test
+    fun edit_distance_preference() {
+        val mr = Fuzzy.rank("mr", "Meera")
+        val rav = Fuzzy.rank("rav", "Ravi")
+        assertTrue(mr > Fuzzy.rank("mr", "Ravi"))
+        assertTrue(rav > Fuzzy.rank("rav", "Meera"))
+    }
+
+    @Test
+    fun deterministic_tieBreaker() {
+        val list = listOf("Alan", "Al")
+        val sorted = list.sortedWith(
+            compareByDescending<String> { Fuzzy.rank("al", it) }
+                .thenBy { it.length }
+                .thenBy { it }
+        )
+        assertEquals("Al", sorted.first())
+    }
+}

--- a/app/src/test/java/com/splitpaisa/core/search/TextNormalizerTest.kt
+++ b/app/src/test/java/com/splitpaisa/core/search/TextNormalizerTest.kt
@@ -1,0 +1,18 @@
+package com.splitpaisa.core.search
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TextNormalizerTest {
+    @Test
+    fun normalize_basic() {
+        assertEquals("jose", TextNormalizer.normalize("José"))
+        assertEquals("hello world", TextNormalizer.normalize("  Hello   World  "))
+    }
+
+    @Test
+    fun tokenize_splits() {
+        val tokens = TextNormalizer.tokenize("Ångström Unit")
+        assertEquals(listOf("angstrom", "unit"), tokens)
+    }
+}

--- a/app/src/test/java/com/splitpaisa/data/FilteringTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/FilteringTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.splitpaisa.core.model.TransactionType
 import com.splitpaisa.data.local.db.PaisaSplitDatabase
 import com.splitpaisa.data.local.entity.CategoryEntity
+import com.splitpaisa.core.search.TextNormalizer
 import com.splitpaisa.data.local.entity.TransactionEntity
 import com.splitpaisa.data.repo.TxFilter
 import com.splitpaisa.data.repo.TransactionsRepository
@@ -44,8 +45,8 @@ class FilteringTest {
 
     @Test
     fun listTransactions_filtersByCategoryAndDate() = runBlocking {
-        val cat1 = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null)
-        val cat2 = CategoryEntity("c2", "Travel", TransactionType.EXPENSE, "ic", "#00ff00", null)
+        val cat1 = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null, TextNormalizer.normalize("Food"))
+        val cat2 = CategoryEntity("c2", "Travel", TransactionType.EXPENSE, "ic", "#00ff00", null, TextNormalizer.normalize("Travel"))
         db.categoryDao().upsert(listOf(cat1, cat2))
         val bounds = lastNMonthsBounds(1).first()
         db.transactionDao().upsert(listOf(

--- a/app/src/test/java/com/splitpaisa/data/GlobalSearchTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/GlobalSearchTest.kt
@@ -1,0 +1,56 @@
+package com.splitpaisa.data
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.splitpaisa.core.model.TransactionType
+import com.splitpaisa.core.search.TextNormalizer
+import com.splitpaisa.data.local.db.PaisaSplitDatabase
+import com.splitpaisa.data.local.entity.CategoryEntity
+import com.splitpaisa.data.local.entity.PartyEntity
+import com.splitpaisa.data.local.entity.TransactionEntity
+import com.splitpaisa.data.repo.SearchRepository
+import com.splitpaisa.data.repo.SearchRepositoryImpl
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GlobalSearchTest {
+    private lateinit var db: PaisaSplitDatabase
+    private lateinit var repo: SearchRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        db = Room.inMemoryDatabaseBuilder(context, PaisaSplitDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repo = SearchRepositoryImpl(db.categoryDao(), db.partyDao(), db.transactionDao(), db.recentSearchDao())
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    @Test
+    fun searchAndRecents() = runBlocking {
+        val cat = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null, TextNormalizer.normalize("Food"))
+        db.categoryDao().upsert(listOf(cat))
+        db.partyDao().upsert(PartyEntity("p1", "Dinner Club", 0))
+        db.transactionDao().upsert(
+            TransactionEntity("t1", TransactionType.EXPENSE, "Dinner", 1000, 1, "c1", null, null, null, null, null, null)
+        )
+        val res = repo.searchAll("din").first()
+        assertEquals(1, res.transactions.size)
+        assertEquals("t1", res.transactions.first().id)
+        repo.recordRecentQuery("din")
+        repo.recordRecentQuery("food")
+        repo.recordRecentQuery("din")
+        val recents = repo.recentQueries().first()
+        assertEquals(listOf("din", "food"), recents)
+    }
+}

--- a/app/src/test/java/com/splitpaisa/data/MemberSearchTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/MemberSearchTest.kt
@@ -1,0 +1,51 @@
+package com.splitpaisa.data
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.splitpaisa.core.search.TextNormalizer
+import com.splitpaisa.data.local.db.PaisaSplitDatabase
+import com.splitpaisa.data.local.entity.PartyEntity
+import com.splitpaisa.data.local.entity.PartyMemberEntity
+import com.splitpaisa.data.repo.PartiesRepository
+import com.splitpaisa.data.repo.PartiesRepositoryImpl
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MemberSearchTest {
+    private lateinit var db: PaisaSplitDatabase
+    private lateinit var repo: PartiesRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        db = Room.inMemoryDatabaseBuilder(context, PaisaSplitDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repo = PartiesRepositoryImpl(db.partyDao(), db.partyMemberDao(), db.transactionDao(), db.splitDao(), db.settlementDao())
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    @Test
+    fun searchRanksAndExcludes() = runBlocking {
+        db.partyDao().upsert(PartyEntity("p1", "Trip", 0))
+        val members = listOf(
+            PartyMemberEntity("m1", "p1", "Meera", null, TextNormalizer.normalize("Meera")),
+            PartyMemberEntity("m2", "p1", "Ravi", null, TextNormalizer.normalize("Ravi"))
+        )
+        db.partyMemberDao().upsert(members)
+        val res = repo.searchMembers("mr").first()
+        assertEquals("Meera", res.first().displayName)
+        val res2 = repo.searchMembers("r", setOf("m2")).first()
+        assertTrue(res2.none { it.id == "m2" })
+    }
+}

--- a/app/src/test/java/com/splitpaisa/data/StatsAggregationTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/StatsAggregationTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.splitpaisa.core.model.TransactionType
 import com.splitpaisa.data.local.db.PaisaSplitDatabase
 import com.splitpaisa.data.local.entity.CategoryEntity
+import com.splitpaisa.core.search.TextNormalizer
 import com.splitpaisa.data.local.entity.TransactionEntity
 import com.splitpaisa.data.repo.TransactionsRepository
 import com.splitpaisa.data.repo.TransactionsRepositoryImpl
@@ -45,8 +46,8 @@ class StatsAggregationTest {
 
     @Test
     fun spendByCategory_sumsAndSorts() = runBlocking {
-        val food = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null)
-        val travel = CategoryEntity("c2", "Travel", TransactionType.EXPENSE, "ic", "#00ff00", null)
+        val food = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null, TextNormalizer.normalize("Food"))
+        val travel = CategoryEntity("c2", "Travel", TransactionType.EXPENSE, "ic", "#00ff00", null, TextNormalizer.normalize("Travel"))
         db.categoryDao().upsert(listOf(food, travel))
         val (start, end) = lastNMonthsBounds(1).first().run { start to end }
         db.transactionDao().upsert(listOf(
@@ -61,7 +62,7 @@ class StatsAggregationTest {
     @Test
     fun monthlyTrend_gapFilled() = runBlocking {
         val bounds = lastNMonthsBounds(3)
-        val food = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null)
+        val food = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null, TextNormalizer.normalize("Food"))
         db.categoryDao().upsert(listOf(food))
         db.transactionDao().upsert(
             TransactionEntity("t1", TransactionType.EXPENSE, "A", 1000, bounds[0].start + 1, "c1", null, null, null, null, null, null)
@@ -74,7 +75,7 @@ class StatsAggregationTest {
 
     @Test
     fun budgetVsActual_basic() = runBlocking {
-        val cat = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", 2000)
+        val cat = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", 2000, TextNormalizer.normalize("Food"))
         db.categoryDao().upsert(listOf(cat))
         val (start, end) = lastNMonthsBounds(1).first().run { start to end }
         db.transactionDao().upsert(
@@ -87,9 +88,9 @@ class StatsAggregationTest {
 
     @Test
     fun topCategories_limit() = runBlocking {
-        val food = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null)
-        val travel = CategoryEntity("c2", "Travel", TransactionType.EXPENSE, "ic", "#00ff00", null)
-        val rent = CategoryEntity("c3", "Rent", TransactionType.EXPENSE, "ic", "#0000ff", null)
+        val food = CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#ff0000", null, TextNormalizer.normalize("Food"))
+        val travel = CategoryEntity("c2", "Travel", TransactionType.EXPENSE, "ic", "#00ff00", null, TextNormalizer.normalize("Travel"))
+        val rent = CategoryEntity("c3", "Rent", TransactionType.EXPENSE, "ic", "#0000ff", null, TextNormalizer.normalize("Rent"))
         db.categoryDao().upsert(listOf(food, travel, rent))
         val (start, end) = lastNMonthsBounds(1).first().run { start to end }
         db.transactionDao().upsert(listOf(

--- a/app/src/test/java/com/splitpaisa/data/local/DatabaseTest.kt
+++ b/app/src/test/java/com/splitpaisa/data/local/DatabaseTest.kt
@@ -10,6 +10,7 @@ import com.splitpaisa.data.local.entity.PartyEntity
 import com.splitpaisa.data.local.entity.PartyMemberEntity
 import com.splitpaisa.data.local.entity.SplitEntity
 import com.splitpaisa.data.local.entity.TransactionEntity
+import com.splitpaisa.core.search.TextNormalizer
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -39,7 +40,7 @@ class DatabaseTest {
     @Test
     fun accountAndCategoryRoundTrip() = runBlocking {
         db.accountDao().insertAll(listOf(AccountEntity("a1", "Wallet", "CASH")))
-        db.categoryDao().upsert(listOf(CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#fff", null)))
+        db.categoryDao().upsert(listOf(CategoryEntity("c1", "Food", TransactionType.EXPENSE, "ic", "#fff", null, TextNormalizer.normalize("Food"))))
 
         val accounts = db.accountDao().getAll().first()
         val categories = db.categoryDao().getAll().first()
@@ -70,8 +71,8 @@ class DatabaseTest {
         val party = PartyEntity("p1", "Trip", 0)
         db.partyDao().upsert(party)
         val members = listOf(
-            PartyMemberEntity("m1", "p1", "A", null),
-            PartyMemberEntity("m2", "p1", "B", null)
+            PartyMemberEntity("m1", "p1", "A", null, TextNormalizer.normalize("A")),
+            PartyMemberEntity("m2", "p1", "B", null, TextNormalizer.normalize("B"))
         )
         db.partyMemberDao().upsert(members)
         val tx = TransactionEntity("t1", TransactionType.EXPENSE, "Taxi", 1000, 1, null, null, "p1", null, null, null, null)


### PR DESCRIPTION
## Summary
- add lightweight text normalization and fuzzy ranking utilities
- enable fuzzy member search with deterministic ranking and duplicate exclusion
- introduce global search across transactions, categories, and parties with MRU suggestions stored in Room

## Testing
- No tests run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_689b3a2a8b4c8333a5f316e56a9779e4