### PR TITLE
feat(settings): app lock, DataStore prefs, CSV export/import stubs, and backups (no Gradle in Codex)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,11 @@ dependencies {
   implementation("androidx.navigation:navigation-compose:2.7.7")
   implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.3")
   implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.3")
+  implementation("androidx.datastore:datastore:1.1.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-protobuf:1.6.3")
+  implementation("androidx.security:security-crypto:1.1.0-alpha06")
+  implementation("androidx.biometric:biometric:1.2.0-alpha05")
+  implementation("androidx.work:work-runtime-ktx:2.9.0")
 
   val roomVersion = "2.6.1"
   implementation("androidx.room:room-runtime:$roomVersion")

--- a/app/src/main/java/com/splitpaisa/MainActivity.kt
+++ b/app/src/main/java/com/splitpaisa/MainActivity.kt
@@ -22,36 +22,56 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.splitpaisa.core.ui.PaisaSplitTheme
 import com.splitpaisa.feature.settings.SettingsViewModel
-import com.splitpaisa.feature.settings.ThemeMode
+import com.splitpaisa.core.prefs.ThemeMode
+import com.splitpaisa.core.security.AppLockManager
+import com.splitpaisa.core.prefs.SettingsRepository
+import com.splitpaisa.core.prefs.settingsDataStore
+import kotlinx.coroutines.launch
 import com.splitpaisa.navigation.Destinations
 import com.splitpaisa.navigation.PaisaNavGraph
+import com.splitpaisa.feature.settings.LockScreen
+import androidx.compose.runtime.rememberCoroutineScope
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            val settingsViewModel: SettingsViewModel = viewModel()
+            val settingsViewModel: SettingsViewModel = viewModel(factory = SettingsViewModel.factory(this))
             val settingsState by settingsViewModel.uiState.collectAsState()
-            val darkTheme = when (settingsState.theme) {
+            val darkTheme = when (settingsState.themeMode) {
                 ThemeMode.DARK -> true
                 ThemeMode.LIGHT -> false
                 ThemeMode.SYSTEM -> isSystemInDarkTheme()
             }
+            val lockManager = remember { AppLockManager(this, SettingsRepository(this.settingsDataStore)) }
+            var locked by remember { mutableStateOf(false) }
+            LaunchedEffect(Unit) {
+                locked = lockManager.isLockRequired()
+            }
             PaisaSplitTheme(darkTheme) {
-                val navController = rememberNavController()
-                Scaffold(
-                    bottomBar = { BottomBar(navController) },
-                    floatingActionButton = {
-                        FloatingActionButton(onClick = { navController.navigate(Destinations.Add.route) }) {
-                            Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.add))
+                if (locked) {
+                    LockScreen { pin ->
+                        if (lockManager.verifyPin(pin)) {
+                            val scope = rememberCoroutineScope()
+                            scope.launch { lockManager.recordUnlock(); locked = false }
                         }
                     }
-                ) { inner ->
-                    PaisaNavGraph(
-                        navController = navController,
-                        settingsViewModel = settingsViewModel,
-                        modifier = Modifier.padding(inner)
-                    )
+                } else {
+                    val navController = rememberNavController()
+                    Scaffold(
+                        bottomBar = { BottomBar(navController) },
+                        floatingActionButton = {
+                            FloatingActionButton(onClick = { navController.navigate(Destinations.Add.route) }) {
+                                Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.add))
+                            }
+                        }
+                    ) { inner ->
+                        PaisaNavGraph(
+                            navController = navController,
+                            settingsViewModel = settingsViewModel,
+                            modifier = Modifier.padding(inner)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/splitpaisa/core/backup/ZipHelper.kt
+++ b/app/src/main/java/com/splitpaisa/core/backup/ZipHelper.kt
@@ -1,0 +1,28 @@
+package com.splitpaisa.core.backup
+
+import java.io.OutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+object ZipHelper {
+    fun write(files: Map<String, ByteArray>, out: OutputStream) {
+        ZipOutputStream(out).use { zip ->
+            files.forEach { (name, bytes) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(bytes)
+                zip.closeEntry()
+            }
+        }
+    }
+
+    fun listEntries(input: ZipInputStream): List<String> {
+        val names = mutableListOf<String>()
+        var entry = input.nextEntry
+        while (entry != null) {
+            names += entry.name
+            entry = input.nextEntry
+        }
+        return names
+    }
+}

--- a/app/src/main/java/com/splitpaisa/core/csv/CsvModels.kt
+++ b/app/src/main/java/com/splitpaisa/core/csv/CsvModels.kt
@@ -1,0 +1,35 @@
+package com.splitpaisa.core.csv
+
+data class AccountCsv(val id: String, val name: String, val type: String)
+data class CategoryCsv(
+    val id: String,
+    val name: String,
+    val kind: String,
+    val icon: String?,
+    val color: String?,
+    val monthlyBudgetPaise: Long?
+)
+data class TransactionCsv(
+    val id: String,
+    val type: String,
+    val title: String,
+    val amountPaise: Long,
+    val atEpochMillis: Long,
+    val categoryId: String?,
+    val accountId: String?,
+    val partyId: String?,
+    val notes: String?
+)
+data class PartyCsv(val id: String, val name: String, val createdAt: Long)
+data class MemberCsv(val id: String, val partyId: String, val displayName: String, val contact: String?)
+data class SplitCsv(val id: String, val transactionId: String, val memberId: String, val sharePaise: Long)
+data class SettlementCsv(
+    val id: String,
+    val partyId: String,
+    val payerId: String,
+    val payeeId: String,
+    val amountPaise: Long,
+    val methodNote: String?,
+    val atEpochMillis: Long,
+    val memo: String?
+)

--- a/app/src/main/java/com/splitpaisa/core/csv/CsvReader.kt
+++ b/app/src/main/java/com/splitpaisa/core/csv/CsvReader.kt
@@ -1,0 +1,15 @@
+package com.splitpaisa.core.csv
+
+import java.io.InputStream
+
+object CsvReader {
+    fun preview(input: InputStream, limit: Int = 20): List<List<String>> {
+        val rows = mutableListOf<List<String>>()
+        input.bufferedReader().useLines { seq ->
+            seq.take(limit).forEach { line ->
+                rows += line.split(",")
+            }
+        }
+        return rows
+    }
+}

--- a/app/src/main/java/com/splitpaisa/core/csv/CsvWriter.kt
+++ b/app/src/main/java/com/splitpaisa/core/csv/CsvWriter.kt
@@ -1,0 +1,57 @@
+package com.splitpaisa.core.csv
+
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+object CsvWriter {
+    fun writeAccounts(accounts: List<AccountCsv>, out: OutputStream) = write(
+        listOf("id,name,type"),
+        accounts.map { listOf(it.id, it.name, it.type) },
+        out
+    )
+
+    fun writeCategories(categories: List<CategoryCsv>, out: OutputStream) = write(
+        listOf("id,name,kind,icon,color,monthlyBudgetPaise"),
+        categories.map { listOf(it.id, it.name, it.kind, it.icon ?: "", it.color ?: "", it.monthlyBudgetPaise?.toString() ?: "") },
+        out
+    )
+
+    fun writeTransactions(txs: List<TransactionCsv>, out: OutputStream) = write(
+        listOf("id,type,title,amountPaise,atEpochMillis,categoryId,accountId,partyId,notes"),
+        txs.map { listOf(it.id, it.type, it.title, it.amountPaise.toString(), it.atEpochMillis.toString(), it.categoryId ?: "", it.accountId ?: "", it.partyId ?: "", it.notes ?: "") },
+        out
+    )
+
+    fun writeParties(parties: List<PartyCsv>, out: OutputStream) = write(
+        listOf("id,name,createdAt"),
+        parties.map { listOf(it.id, it.name, it.createdAt.toString()) },
+        out
+    )
+
+    fun writeMembers(members: List<MemberCsv>, out: OutputStream) = write(
+        listOf("id,partyId,displayName,contact"),
+        members.map { listOf(it.id, it.partyId, it.displayName, it.contact ?: "") },
+        out
+    )
+
+    fun writeSplits(splits: List<SplitCsv>, out: OutputStream) = write(
+        listOf("id,transactionId,memberId,sharePaise"),
+        splits.map { listOf(it.id, it.transactionId, it.memberId, it.sharePaise.toString()) },
+        out
+    )
+
+    fun writeSettlements(rows: List<SettlementCsv>, out: OutputStream) = write(
+        listOf("id,partyId,payerId,payeeId,amountPaise,methodNote,atEpochMillis,memo"),
+        rows.map { listOf(it.id, it.partyId, it.payerId, it.payeeId, it.amountPaise.toString(), it.methodNote ?: "", it.atEpochMillis.toString(), it.memo ?: "") },
+        out
+    )
+
+    private fun write(header: List<String>, rows: List<List<String>>, out: OutputStream) {
+        out.bufferedWriter().use { writer ->
+            writer.appendLine(header.joinToString(","))
+            rows.forEach { row ->
+                writer.appendLine(row.joinToString(","))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/splitpaisa/core/prefs/SettingsDataStore.kt
+++ b/app/src/main/java/com/splitpaisa/core/prefs/SettingsDataStore.kt
@@ -1,0 +1,52 @@
+package com.splitpaisa.core.prefs
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.serialization.protobuf.ProtoNumber
+import java.io.InputStream
+import java.io.OutputStream
+
+@Serializable
+enum class ThemeMode {
+    @ProtoNumber(0) SYSTEM,
+    @ProtoNumber(1) LIGHT,
+    @ProtoNumber(2) DARK
+}
+
+@Serializable
+data class Settings(
+    @ProtoNumber(1) val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    @ProtoNumber(2) val currencyCode: String = "INR",
+    @ProtoNumber(3) val dateFormat: String = "dd-MM-yyyy",
+    @ProtoNumber(4) val hideAmounts: Boolean = false,
+    @ProtoNumber(5) val appLockEnabled: Boolean = false,
+    @ProtoNumber(6) val autoLockMinutes: Int = 0,
+    @ProtoNumber(7) val lastLockTimestamp: Long = 0L,
+    @ProtoNumber(8) val budgetAlert75: Boolean = false,
+    @ProtoNumber(9) val budgetAlert100: Boolean = false,
+    @ProtoNumber(10) val settleUpReminder: Boolean = false,
+    @ProtoNumber(11) val offlineOnly: Boolean = true
+)
+
+object SettingsSerializer : Serializer<Settings> {
+    override val defaultValue: Settings = Settings()
+
+    override suspend fun readFrom(input: InputStream): Settings = try {
+        ProtoBuf.decodeFromByteArray(Settings.serializer(), input.readBytes())
+    } catch (e: Exception) {
+        Settings()
+    }
+
+    override suspend fun writeTo(t: Settings, output: OutputStream) {
+        output.write(ProtoBuf.encodeToByteArray(Settings.serializer(), t))
+    }
+}
+
+val Context.settingsDataStore: DataStore<Settings> by dataStore(
+    fileName = "settings.pb",
+    serializer = SettingsSerializer
+)

--- a/app/src/main/java/com/splitpaisa/core/prefs/SettingsRepository.kt
+++ b/app/src/main/java/com/splitpaisa/core/prefs/SettingsRepository.kt
@@ -1,0 +1,23 @@
+package com.splitpaisa.core.prefs
+
+import androidx.datastore.core.DataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+
+class SettingsRepository(private val dataStore: DataStore<Settings>) {
+    val settings: Flow<Settings> = dataStore.data
+
+    suspend fun setTheme(mode: ThemeMode) = update { it.copy(themeMode = mode) }
+    suspend fun setHideAmounts(hide: Boolean) = update { it.copy(hideAmounts = hide) }
+    suspend fun setOfflineOnly(offline: Boolean) = update { it.copy(offlineOnly = offline) }
+    suspend fun setAppLock(enabled: Boolean) = update { it.copy(appLockEnabled = enabled) }
+    suspend fun setAutoLock(minutes: Int) = update { it.copy(autoLockMinutes = minutes) }
+    suspend fun setLastUnlock(timestamp: Long) = update { it.copy(lastLockTimestamp = timestamp) }
+    suspend fun setBudgetAlerts(p75: Boolean, p100: Boolean) = update { it.copy(budgetAlert75 = p75, budgetAlert100 = p100) }
+    suspend fun setSettleUpReminder(enabled: Boolean) = update { it.copy(settleUpReminder = enabled) }
+
+    private suspend fun update(block: (Settings) -> Settings) {
+        dataStore.updateData { current -> block(current) }
+    }
+}

--- a/app/src/main/java/com/splitpaisa/core/security/AppLockManager.kt
+++ b/app/src/main/java/com/splitpaisa/core/security/AppLockManager.kt
@@ -1,0 +1,29 @@
+package com.splitpaisa.core.security
+
+import android.content.Context
+import com.splitpaisa.core.prefs.SettingsRepository
+import kotlinx.coroutines.flow.first
+
+class AppLockManager(
+    private val context: Context,
+    private val settingsRepository: SettingsRepository
+) {
+    private val pinStorage = PinStorage(context)
+
+    suspend fun isLockRequired(): Boolean {
+        val s = settingsRepository.settings.first()
+        if (!s.appLockEnabled) return false
+        if (s.autoLockMinutes <= 0) return true
+        val now = System.currentTimeMillis()
+        return now - s.lastLockTimestamp > s.autoLockMinutes * 60 * 1000
+    }
+
+    suspend fun recordUnlock() {
+        settingsRepository.setLastUnlock(System.currentTimeMillis())
+    }
+
+    fun verifyPin(pin: String): Boolean = pinStorage.verifyPin(pin)
+
+    fun savePin(pin: String) { pinStorage.savePin(pin) }
+    fun clearPin() { pinStorage.clear() }
+}

--- a/app/src/main/java/com/splitpaisa/core/security/BiometricGate.kt
+++ b/app/src/main/java/com/splitpaisa/core/security/BiometricGate.kt
@@ -1,0 +1,38 @@
+package com.splitpaisa.core.security
+
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.fragment.app.FragmentActivity
+import java.util.concurrent.Executor
+
+object BiometricGate {
+    fun canUse(activity: FragmentActivity): Boolean {
+        val manager = BiometricManager.from(activity)
+        return manager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL) == BiometricManager.BIOMETRIC_SUCCESS
+    }
+
+    fun authenticate(
+        activity: FragmentActivity,
+        executor: Executor,
+        onResult: (Boolean) -> Unit
+    ) {
+        val prompt = BiometricPrompt(activity, executor, object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                onResult(true)
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                onResult(false)
+            }
+
+            override fun onAuthenticationFailed() {
+                onResult(false)
+            }
+        })
+        val info = BiometricPrompt.PromptInfo.Builder()
+            .setTitle("Unlock")
+            .setDeviceCredentialAllowed(true)
+            .build()
+        prompt.authenticate(info)
+    }
+}

--- a/app/src/main/java/com/splitpaisa/core/security/EncryptedPrefs.kt
+++ b/app/src/main/java/com/splitpaisa/core/security/EncryptedPrefs.kt
@@ -1,0 +1,27 @@
+package com.splitpaisa.core.security
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+class EncryptedPrefs(context: Context) {
+    private val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val prefs = EncryptedSharedPreferences.create(
+        context,
+        "secure_prefs",
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    fun getString(key: String): String? = prefs.getString(key, null)
+
+    fun putString(key: String, value: String) {
+        prefs.edit().putString(key, value).apply()
+    }
+
+    fun remove(key: String) { prefs.edit().remove(key).apply() }
+}

--- a/app/src/main/java/com/splitpaisa/core/security/PinHasher.kt
+++ b/app/src/main/java/com/splitpaisa/core/security/PinHasher.kt
@@ -1,0 +1,17 @@
+package com.splitpaisa.core.security
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+object PinHasher {
+    private val random = SecureRandom()
+
+    fun randomSalt(): ByteArray = ByteArray(16).also { random.nextBytes(it) }
+
+    fun hash(pin: String, salt: ByteArray): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        md.update(salt)
+        md.update(pin.toByteArray())
+        return md.digest().joinToString(separator = "") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/java/com/splitpaisa/core/security/PinStorage.kt
+++ b/app/src/main/java/com/splitpaisa/core/security/PinStorage.kt
@@ -1,0 +1,33 @@
+package com.splitpaisa.core.security
+
+import android.content.Context
+import android.util.Base64
+
+class PinStorage(context: Context) {
+    private val prefs = EncryptedPrefs(context)
+
+    fun savePin(pin: String) {
+        val salt = PinHasher.randomSalt()
+        val hash = PinHasher.hash(pin, salt)
+        prefs.putString(KEY_SALT, Base64.encodeToString(salt, Base64.DEFAULT))
+        prefs.putString(KEY_HASH, hash)
+    }
+
+    fun verifyPin(pin: String): Boolean {
+        val saltB64 = prefs.getString(KEY_SALT) ?: return false
+        val hashStored = prefs.getString(KEY_HASH) ?: return false
+        val salt = Base64.decode(saltB64, Base64.DEFAULT)
+        val hash = PinHasher.hash(pin, salt)
+        return hashStored == hash
+    }
+
+    fun clear() {
+        prefs.remove(KEY_SALT)
+        prefs.remove(KEY_HASH)
+    }
+
+    companion object {
+        private const val KEY_SALT = "pin_salt"
+        private const val KEY_HASH = "pin_hash"
+    }
+}

--- a/app/src/main/java/com/splitpaisa/feature/settings/LockScreen.kt
+++ b/app/src/main/java/com/splitpaisa/feature/settings/LockScreen.kt
@@ -1,0 +1,24 @@
+package com.splitpaisa.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LockScreen(onSubmit: (String) -> Unit) {
+    val pin = remember { mutableStateOf("") }
+    Column(modifier = Modifier.padding(32.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text("Enter PIN")
+        TextField(value = pin.value, onValueChange = { pin.value = it })
+        Button(onClick = { onSubmit(pin.value) }, modifier = Modifier.fillMaxWidth()) { Text("Unlock") }
+    }
+}

--- a/app/src/main/java/com/splitpaisa/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/splitpaisa/feature/settings/SettingsScreen.kt
@@ -1,5 +1,8 @@
 package com.splitpaisa.feature.settings
 
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,43 +10,140 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.AlertDialog
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.splitpaisa.core.csv.CsvReader
+import com.splitpaisa.core.prefs.settingsDataStore
+import androidx.compose.runtime.rememberCoroutineScope
 
 @Composable
 fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
     val state by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    val exportLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
+        if (uri != null) {
+            Toast.makeText(context, "Exported", Toast.LENGTH_SHORT).show()
+        }
+    }
+    val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        if (uri != null) {
+            context.contentResolver.openInputStream(uri)?.use {
+                val preview = CsvReader.preview(it)
+                Toast.makeText(context, "Imported ${preview.size} rows", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
     Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         Text(text = "Settings", style = MaterialTheme.typography.titleLarge)
 
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
             Text("Offline-only", modifier = Modifier.weight(1f))
-            Switch(checked = state.offlineOnly, onCheckedChange = viewModel::toggleOfflineOnly)
-        }
-
-        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-            Text("Hide amounts on Home", modifier = Modifier.weight(1f))
-            Switch(checked = state.hideAmounts, onCheckedChange = viewModel::toggleHideAmounts)
+            Switch(checked = state.offlineOnly, onCheckedChange = { viewModel.toggleOfflineOnly(it) })
         }
 
         Text("Theme", style = MaterialTheme.typography.titleMedium)
         ThemeMode.values().forEach { mode ->
             Row(verticalAlignment = Alignment.CenterVertically) {
-                RadioButton(selected = state.theme == mode, onClick = { viewModel.setTheme(mode) })
+                RadioButton(selected = state.themeMode == mode, onClick = { viewModel.setTheme(mode) })
                 Text(mode.name.lowercase().replaceFirstChar { it.uppercase() })
             }
         }
 
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Text("Hide amounts on Home", modifier = Modifier.weight(1f))
+            Switch(checked = state.hideAmounts, onCheckedChange = { viewModel.toggleHideAmounts(it) })
+        }
+
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Text("App lock", modifier = Modifier.weight(1f))
+            val showDialog = remember { mutableStateOf(false) }
+            val lockManager = remember { com.splitpaisa.core.security.AppLockManager(context, com.splitpaisa.core.prefs.SettingsRepository(context.settingsDataStore)) }
+            Switch(checked = state.appLockEnabled, onCheckedChange = {
+                if (it) showDialog.value = true else viewModel.setAppLock(false)
+            })
+            if (showDialog.value) {
+                PinSetDialog(onSet = { pin ->
+                    lockManager.savePin(pin)
+                    viewModel.setAppLock(true)
+                    showDialog.value = false
+                }, onCancel = {
+                    showDialog.value = false
+                })
+            }
+        }
+        if (state.appLockEnabled) {
+            var minsText by remember { mutableStateOf(state.autoLockMinutes.toString()) }
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                Text("Auto-lock minutes", modifier = Modifier.weight(1f))
+                TextField(value = minsText, onValueChange = {
+                    minsText = it
+                    it.toIntOrNull()?.let(viewModel::setAutoLock)
+                })
+            }
+        }
+
         Spacer(Modifier.height(8.dp))
-        Text("Date format: dd-MM-yyyy")
+        Text("Data", style = MaterialTheme.typography.titleMedium)
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = { exportLauncher.launch("paisa-export.zip") }) { Text("Export") }
+            Button(onClick = { importLauncher.launch(arrayOf("text/*", "application/zip")) }) { Text("Import") }
+        }
+
+        Spacer(Modifier.height(8.dp))
+        Text("Notifications", style = MaterialTheme.typography.titleMedium)
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Text("Budget 75%", modifier = Modifier.weight(1f))
+            Switch(checked = state.budgetAlert75, onCheckedChange = { viewModel.setBudgetAlerts(it, state.budgetAlert100) })
+        }
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Text("Budget 100%", modifier = Modifier.weight(1f))
+            Switch(checked = state.budgetAlert100, onCheckedChange = { viewModel.setBudgetAlerts(state.budgetAlert75, it) })
+        }
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Text("Settle-up reminders", modifier = Modifier.weight(1f))
+            Switch(checked = state.settleUpReminder, onCheckedChange = { viewModel.setSettleReminder(it) })
+        }
+
+        Spacer(Modifier.height(8.dp))
+        Text("Date format: ${state.dateFormat}")
     }
+}
+
+@Composable
+fun PinSetDialog(onSet: (String) -> Unit, onCancel: () -> Unit) {
+    val pin1 = remember { mutableStateOf("") }
+    val pin2 = remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onCancel,
+        confirmButton = {
+            Button(onClick = { if (pin1.value == pin2.value && pin1.value.length >= 4) onSet(pin1.value) }) {
+                Text("Set")
+            }
+        },
+        dismissButton = { Button(onClick = onCancel) { Text("Cancel") } },
+        title = { Text("Set PIN") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextField(value = pin1.value, onValueChange = { pin1.value = it }, label = { Text("PIN") })
+                TextField(value = pin2.value, onValueChange = { pin2.value = it }, label = { Text("Confirm PIN") })
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/splitpaisa/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/splitpaisa/feature/settings/SettingsViewModel.kt
@@ -1,30 +1,42 @@
 package com.splitpaisa.feature.settings
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.splitpaisa.core.prefs.Settings
+import com.splitpaisa.core.prefs.SettingsRepository
+import com.splitpaisa.core.prefs.ThemeMode
+import com.splitpaisa.core.prefs.settingsDataStore
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
-data class SettingsUiState(
-    val offlineOnly: Boolean = true,
-    val theme: ThemeMode = ThemeMode.SYSTEM,
-    val hideAmounts: Boolean = false
-)
+class SettingsViewModel(private val repo: SettingsRepository) : ViewModel() {
+    val uiState: StateFlow<Settings> = repo.settings.stateIn(viewModelScope, SharingStarted.Eagerly, Settings())
 
-enum class ThemeMode { SYSTEM, LIGHT, DARK }
-
-class SettingsViewModel : ViewModel() {
-    private val _uiState = MutableStateFlow(SettingsUiState())
-    val uiState: StateFlow<SettingsUiState> = _uiState
-
-    fun toggleOfflineOnly(value: Boolean) {
-        _uiState.value = _uiState.value.copy(offlineOnly = value)
+    fun toggleOfflineOnly(value: Boolean) = viewModelScope.launch {
+        repo.setOfflineOnly(value)
     }
 
-    fun toggleHideAmounts(value: Boolean) {
-        _uiState.value = _uiState.value.copy(hideAmounts = value)
+    fun toggleHideAmounts(value: Boolean) = viewModelScope.launch {
+        repo.setHideAmounts(value)
     }
 
-    fun setTheme(mode: ThemeMode) {
-        _uiState.value = _uiState.value.copy(theme = mode)
+    fun setTheme(mode: ThemeMode) = viewModelScope.launch { repo.setTheme(mode) }
+    fun setAppLock(enabled: Boolean) = viewModelScope.launch { repo.setAppLock(enabled) }
+    fun setAutoLock(mins: Int) = viewModelScope.launch { repo.setAutoLock(mins) }
+    fun setBudgetAlerts(p75: Boolean, p100: Boolean) = viewModelScope.launch { repo.setBudgetAlerts(p75, p100) }
+    fun setSettleReminder(enabled: Boolean) = viewModelScope.launch { repo.setSettleUpReminder(enabled) }
+
+    companion object {
+        fun factory(context: Context): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                val repo = SettingsRepository(context.settingsDataStore)
+                @Suppress("UNCHECKED_CAST")
+                return SettingsViewModel(repo) as T
+            }
+        }
     }
 }

--- a/app/src/main/java/com/splitpaisa/work/ReminderWorkers.kt
+++ b/app/src/main/java/com/splitpaisa/work/ReminderWorkers.kt
@@ -1,0 +1,36 @@
+package com.splitpaisa.work
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.util.concurrent.TimeUnit
+
+class BudgetAlertWorker(appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        Log.d("BudgetAlert", "Budget alert worker running")
+        return Result.success()
+    }
+}
+
+class SettleUpReminderWorker(appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        Log.d("SettleUp", "Settle up reminder worker running")
+        return Result.success()
+    }
+}
+
+object ReminderScheduler {
+    fun scheduleBudget(context: Context) {
+        val request = PeriodicWorkRequestBuilder<BudgetAlertWorker>(1, TimeUnit.DAYS).build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork("budget-alert", ExistingPeriodicWorkPolicy.UPDATE, request)
+    }
+
+    fun scheduleSettle(context: Context) {
+        val request = PeriodicWorkRequestBuilder<SettleUpReminderWorker>(7, TimeUnit.DAYS).build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork("settle-reminder", ExistingPeriodicWorkPolicy.UPDATE, request)
+    }
+}

--- a/app/src/main/proto/com/splitpaisa/core/prefs/settings.proto
+++ b/app/src/main/proto/com/splitpaisa/core/prefs/settings.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+package com.splitpaisa.core.prefs;
+
+message Settings {
+  enum ThemeMode {
+    SYSTEM = 0;
+    LIGHT = 1;
+    DARK = 2;
+  }
+
+  ThemeMode themeMode = 1;
+  string currencyCode = 2;
+  string dateFormat = 3;
+  bool hideAmounts = 4;
+  bool appLockEnabled = 5;
+  int32 autoLockMinutes = 6;
+  int64 lastLockTimestamp = 7;
+  bool budgetAlert75 = 8;
+  bool budgetAlert100 = 9;
+  bool settleUpReminder = 10;
+  bool offlineOnly = 11;
+}


### PR DESCRIPTION
## Summary
- add proto DataStore for theme, privacy, app lock, and notification toggles
- wire settings UI for offline mode, app lock with PIN dialog, export/import stubs, and alerts
- integrate lock screen on launch and basic CSV/ZIP helpers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_689b6ffa0df483339f2529aaee1e1472